### PR TITLE
FIX support Python 3.8 and 3.13

### DIFF
--- a/ra_aid/tools/memory.py
+++ b/ra_aid/tools/memory.py
@@ -1,4 +1,5 @@
-from typing import Dict, List, Any, Union, TypedDict, Optional, Set
+from typing import Dict, List, Any, Union, Optional, Set
+from typing_extensions import TypedDict
 
 class WorkLogEntry(TypedDict):
     timestamp: str


### PR DESCRIPTION
Unexpected and unclear error when using later versions of Python.
This change works for both Python 3.8 and 3.13

This was the error thrown before the change:
```
 ra-aid -m "What is this project about" --research-only --provider anthropic --model claude-3-5-haiku-20241022
Traceback (most recent call last):
  File "/home/jose/.local/bin/ra-aid", line 5, in <module>
    from ra_aid.__main__ import main
  File "/home/jose/src/RA.Aid/ra_aid/__init__.py", line 5, in <module>
    from .agent_utils import run_agent_with_retry
  File "/home/jose/src/RA.Aid/ra_aid/agent_utils.py", line 24, in <module>
    from ra_aid.tool_configs import (
  File "/home/jose/src/RA.Aid/ra_aid/tool_configs.py", line 1, in <module>
    from ra_aid.tools import (
  File "/home/jose/src/RA.Aid/ra_aid/tools/__init__.py", line 1, in <module>
    from .shell import run_shell_command
  File "/home/jose/src/RA.Aid/ra_aid/tools/shell.py", line 6, in <module>
    from ra_aid.tools.memory import _global_memory
  File "/home/jose/src/RA.Aid/ra_aid/tools/memory.py", line 190, in <module>
    def emit_key_snippets(snippets: List[SnippetInfo]) -> str:
  File "/home/jose/.local/lib/python3.10/site-packages/langchain_core/tools/convert.py", line 249, in _tool_factory
    return StructuredTool.from_function(
  File "/home/jose/.local/lib/python3.10/site-packages/langchain_core/tools/structured.py", line 176, in from_function
    args_schema = create_schema_from_function(
  File "/home/jose/.local/lib/python3.10/site-packages/langchain_core/tools/base.py", line 249, in create_schema_from_function
    validated = validate_arguments(func, config=_SchemaConfig)  # type: ignore
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/deprecated/decorator.py", line 64, in validate_arguments
    return validate(func)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/deprecated/decorator.py", line 51, in validate
    vd = ValidatedFunction(_func, config)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/deprecated/decorator.py", line 142, in __init__
    self.create_model(fields, takes_args, takes_kwargs, config)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/deprecated/decorator.py", line 283, in create_model
    self.model = create_model(to_pascal(self.raw_function.__name__), __base__=DecoratorBaseModel, **fields)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/main.py", line 1679, in create_model
    return meta(
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_model_construction.py", line 226, in __new__
    complete_model_class(
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_model_construction.py", line 658, in complete_model_class
    schema = cls.__get_pydantic_core_schema__(cls, handler)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/main.py", line 702, in __get_pydantic_core_schema__
    return handler(source)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_schema_generation_shared.py", line 84, in __call__
    schema = self._handler(source_type)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 610, in generate_schema
    schema = self._generate_schema_inner(obj)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 879, in _generate_schema_inner
    return self._model_schema(obj)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 691, in _model_schema
    {k: self._generate_md_field_schema(k, v, decorators) for k, v in fields.items()},
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 691, in <dictcomp>
    {k: self._generate_md_field_schema(k, v, decorators) for k, v in fields.items()},
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 1071, in _generate_md_field_schema
    common_field = self._common_field_schema(name, field_info, decorators)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 1263, in _common_field_schema
    schema = self._apply_annotations(
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 2056, in _apply_annotations
    schema = get_inner_schema(source_type)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_schema_generation_shared.py", line 84, in __call__
    schema = self._handler(source_type)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 2037, in inner_handler
    schema = self._generate_schema_inner(obj)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 884, in _generate_schema_inner
    return self.match_type(obj)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 986, in match_type
    return self._match_generic_type(obj, origin)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 1018, in _match_generic_type
    return self._list_schema(self._get_first_arg_or_any(obj))
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 367, in _list_schema
    return core_schema.list_schema(self.generate_schema(items_type))
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 610, in generate_schema
    schema = self._generate_schema_inner(obj)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 884, in _generate_schema_inner
    return self.match_type(obj)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 956, in match_type
    return self._typed_dict_schema(obj, None)
  File "/home/jose/.local/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 1406, in _typed_dict_schema
    raise PydanticUserError(
pydantic.errors.PydanticUserError: Please use `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.12.

For further information visit https://errors.pydantic.dev/2.10/u/typed-dict-version
```