### PR TITLE
Corrected typo in documentation for the GitHub URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ RA.Aid implements a three-stage architecture for handling development and resear
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/ai-christianson/ra-aid.git
+git clone https://github.com/ai-christianson/RA.Aid.git
 cd ra-aid
 ```
 

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ RA.Aid implements a three-stage architecture for handling development and resear
 1. Clone the repository:
 ```bash
 git clone https://github.com/ai-christianson/RA.Aid.git
-cd ra-aid
+cd RA.Aid
 ```
 
 2. Create and activate a virtual environment:


### PR DESCRIPTION
There was a small issue in the documentation. The URL for the repo was listed as:

`https://github.com/ai-christianson/ra-aid.git` 

That 404s.

I corrected the instructions to:

```
git clone https://github.com/ai-christianson/RA.Aid.git
cd RA.Aid
```