### PR TITLE
FIX SyntaxError: f-string expression part cannot include a backslash

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "Running tests before push..."
+make test
+RESULT=$?
+
+if [ $RESULT -ne 0 ]; then
+    echo "Tests failed. Push aborted."
+    exit 1
+fi
+
+exit 0

--- a/ra_aid/agents/ciayn_agent.py
+++ b/ra_aid/agents/ciayn_agent.py
@@ -83,6 +83,10 @@ class CiaynAgent:
         if last_result is not None:
             base_prompt += f"\n<last result>{last_result}</last result>"
             
+        # Add available functions section
+        functions_list = "\n\n".join(self.available_functions)
+        
+        # Build the complete prompt without f-strings for the static parts
         base_prompt += """
 
 <agent instructions>
@@ -101,8 +105,7 @@ You typically don't want to keep calling the same function over and over with th
 
 You must ONLY use ONE of the following functions (these are the ONLY functions that exist):
 
-<available functions>
-{"\n\n".join(self.available_functions)}
+<available functions>""" + functions_list + """
 </available functions>
 
 You may use ANY of the above functions to complete your job. Use the best one for the current step you are on. Be efficient, avoid getting stuck in repetitive loops, and do not hesitate to call functions which delegate your work to make your life easier.

--- a/ra_aid/agents/ciayn_agent.py
+++ b/ra_aid/agents/ciayn_agent.py
@@ -83,7 +83,7 @@ class CiaynAgent:
         if last_result is not None:
             base_prompt += f"\n<last result>{last_result}</last result>"
             
-        base_prompt += f"""
+        base_prompt += """
 
 <agent instructions>
 You are a ReAct agent. You run in a loop and use ONE of the available functions per iteration.


### PR DESCRIPTION
1. Fix broken unit tests
2. Establish pre-commit hook to run tests prior to git push
3. FIx the reported error

```
Traceback (most recent call last):
  File "/home/codespace/.python/current/bin/ra-aid", line 5, in <module>
    from ra_aid.__main__ import main
  File "/usr/local/python/3.10.13/lib/python3.10/site-packages/ra_aid/__init__.py", line 5, in <module>
    from .agent_utils import run_agent_with_retry
  File "/usr/local/python/3.10.13/lib/python3.10/site-packages/ra_aid/agent_utils.py", line 14, in <module>
    from ra_aid.agents.ciayn_agent import CiaynAgent
  File "/usr/local/python/3.10.13/lib/python3.10/site-packages/ra_aid/agents/ciayn_agent.py", line 133
    Output **ONLY THE CODE** and **NO MARKDOWN BACKTICKS**"""
                                                             ^
SyntaxError: f-string expression part cannot include a backslash 
```