### PR TITLE
FEAT add function to check for dependencies on startup

### DIFF
--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -27,6 +27,7 @@ from ra_aid.logging_config import setup_logging, get_logger
 from ra_aid.tool_configs import (
     get_chat_tools
 )
+from ra_aid.dependencies import check_dependencies
 import os
 
 logger = get_logger(__name__)
@@ -167,6 +168,9 @@ def main():
     logger.debug("Starting RA.Aid with arguments: %s", args)
 
     try:
+        # Check dependencies before proceeding
+        check_dependencies()
+
         expert_enabled, expert_missing, web_research_enabled, web_research_missing = validate_environment(args)  # Will exit if main env vars missing
         logger.debug("Environment validation successful")
 

--- a/ra_aid/dependencies.py
+++ b/ra_aid/dependencies.py
@@ -1,0 +1,36 @@
+"""Module for checking system dependencies required by RA.Aid."""
+import os
+import sys
+from ra_aid import print_error
+from abc import ABC, abstractmethod
+
+class Dependency(ABC):
+    """Base class for system dependencies."""
+    @abstractmethod
+    def check(self):
+        """Check if the dependency is installed."""
+        pass
+
+class RipGrepDependency(Dependency):
+    """Dependency checker for ripgrep."""
+    def check(self):
+        """Check if ripgrep is installed."""
+        result = os.system('rg --version > /dev/null 2>&1')
+        if result != 0:
+            print_error("Required dependency 'ripgrep' is not installed.")
+            print("Please install ripgrep:")
+            print("  - Ubuntu/Debian: sudo apt-get install ripgrep")
+            print("  - macOS: brew install ripgrep")
+            print("  - Windows: choco install ripgrep")
+            print("  - Other: https://github.com/BurntSushi/ripgrep#installation")
+            sys.exit(1)
+
+def check_dependencies():
+    """Check if required system dependencies are installed."""
+    dependencies = [RipGrepDependency()]  # Create instances
+    try:
+        for dependency in dependencies:
+            dependency.check()
+    except Exception as e:
+        print_error(f"Error checking dependencies: {e}")
+        sys.exit(1)


### PR DESCRIPTION
Added function to check for dependencies such as 'ripgrep'.
This was implemented using an interface to make it extensible and making it a way to add dependencies in the future.