### PR TITLE
Add default support for OpenAI models

### DIFF
--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -34,6 +34,7 @@ logger = get_logger(__name__)
 def parse_arguments(args=None):
     VALID_PROVIDERS = ['anthropic', 'openai', 'openrouter', 'openai-compatible']
     ANTHROPIC_DEFAULT_MODEL = 'claude-3-5-sonnet-20241022'
+    OPENAI_DEFAULT_MODEL = 'gpt-4o'
 
     parser = argparse.ArgumentParser(
         description='RA.Aid - AI Agent for executing programming and research tasks',
@@ -63,7 +64,7 @@ Examples:
     parser.add_argument(
         '--provider',
         type=str,
-        default='anthropic',
+        default='openai' if (os.getenv('OPENAI_API_KEY') and not os.getenv('ANTHROPIC_API_KEY')) else 'anthropic',
         choices=VALID_PROVIDERS,
         help='The LLM provider to use'
     )
@@ -123,6 +124,8 @@ Examples:
     if parsed_args.provider not in VALID_PROVIDERS:
         parser.error(f"Invalid provider: {parsed_args.provider}")
 
+    if parsed_args.provider == "openai":
+        parsed_args.model = parsed_args.model or OPENAI_DEFAULT_MODEL
     # Handle model defaults and requirements
     if parsed_args.provider == 'anthropic':
         # Always use default model for Anthropic

--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -71,7 +71,7 @@ Examples:
     parser.add_argument(
         '--model',
         type=str,
-        help='The model name to use (required for non-Anthropic providers)'
+        help='The model name to use'
     )
     parser.add_argument(
         '--cowboy-mode',
@@ -123,10 +123,10 @@ Examples:
     # Validate provider
     if parsed_args.provider not in VALID_PROVIDERS:
         parser.error(f"Invalid provider: {parsed_args.provider}")
+    # Handle model defaults and requirements
 
     if parsed_args.provider == "openai":
         parsed_args.model = parsed_args.model or OPENAI_DEFAULT_MODEL
-    # Handle model defaults and requirements
     if parsed_args.provider == 'anthropic':
         # Always use default model for Anthropic
         parsed_args.model = ANTHROPIC_DEFAULT_MODEL


### PR DESCRIPTION
Small change to will help users that want to rely on OpenAI. Defaults provider to `openai` if the user has set up the Open AI API key. It also makes a default OpenAI model.