### PR TITLE
chore(dependencies): update aider-chat version from 0.69.1 to 0.72.1 …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "fuzzywuzzy==0.18.0",
     "python-Levenshtein==0.23.0",
     "pathspec>=0.11.0",
-    "aider-chat>=0.69.1",
+    "aider-chat>=0.72.1",
     "tavily-python>=0.5.0",
     "litellm"
 ]


### PR DESCRIPTION
Seems to work fine, this version of aider has deepseek r1 support :)