### PR TITLE
Integrate litellm to retrieve model token limits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "pytest-timeout>=2.2.0",
     "pytest>=7.0.0",
     "pytest-cov>=6.0.0",
+    "pytest-mock>=3.14.0",
 ]
 
 [project.scripts]
@@ -64,3 +65,4 @@ path = "ra_aid/__version__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["ra_aid"]
+

--- a/ra_aid/models_tokens.py
+++ b/ra_aid/models_tokens.py
@@ -4,6 +4,8 @@ List of model tokens
 
 DEFAULT_TOKEN_LIMIT = 100000
 
+
+
 models_tokens = {
     "openai": {
         "gpt-3.5-turbo-0125": 16385,
@@ -241,7 +243,7 @@ models_tokens = {
     "deepseek": {
         "deepseek-chat": 28672,
         "deepseek-coder": 16384,
-        "deepseek-reasoner": 65536,
+        "deepseek-reasoner": 64000,
     },
     "openrouter": {
         "deepseek/deepseek-r1": 65536,


### PR DESCRIPTION
- Use litellm to get `max_input_tokens` by default.
- Fallback to using our LLM dict for missing/new models like `deepseek-reasoner`.
- fix(agent_utils.py): rename max_tokens to max_input_tokens for clarity in state_modifier function
- fix(models_tokens.py): update deepseek-reasoner token limit to 64000 for accuracy
- test(agent_utils.py): add tests for litellm integration and fallback logic in get_model_token_limit function