### PR TITLE
Improve token count for tool call messages

### DIFF
--- a/ra_aid/agents/ciayn_agent.py
+++ b/ra_aid/agents/ciayn_agent.py
@@ -267,7 +267,7 @@ Output **ONLY THE CODE** and **NO MARKDOWN BACKTICKS**"""
 
         # create-react-agent tool calls can be lists
         if isinstance(text, List):
-            return 0
+            text = str(text)
 
         if not text:
             return 0


### PR DESCRIPTION
- Simple conversion of `List` to `str` so we dont count tool call messages as 0 tokens. Hopefully this leads to less max token count errors during long `ra-aid` sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved token estimation method to handle list inputs more effectively by converting lists to strings during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->