### PR TITLE
FIX Do not default to o1 model

### DIFF
--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -206,7 +206,7 @@ Examples:
 
     if parsed_args.provider == "openai":
         parsed_args.model = parsed_args.model or OPENAI_DEFAULT_MODEL
-    if parsed_args.provider == "anthropic":
+    elif parsed_args.provider == "anthropic":
         # Always use default model for Anthropic
         parsed_args.model = ANTHROPIC_DEFAULT_MODEL
     elif not parsed_args.model and not parsed_args.research_only:
@@ -215,15 +215,12 @@ Examples:
             f"--model is required when using provider '{parsed_args.provider}'"
         )
 
-    # Validate expert model requirement
-    if (
-        parsed_args.expert_provider != "openai"
-        and not parsed_args.expert_model
-        and not parsed_args.research_only
-    ):
-        parser.error(
-            f"--expert-model is required when using expert provider '{parsed_args.expert_provider}'"
-        )
+    # Handle expert provider/model defaults
+    if not parsed_args.expert_provider:
+        # If no expert provider specified, use main provider instead of defaulting to
+        # to any particular model since we do not know if we have access to any other model.
+        parsed_args.expert_provider = parsed_args.provider
+        parsed_args.expert_model = parsed_args.model
 
     # Validate temperature range if provided
     if parsed_args.temperature is not None and not (

--- a/ra_aid/llm.py
+++ b/ra_aid/llm.py
@@ -217,7 +217,7 @@ def initialize_llm(
 
 
 def initialize_expert_llm(
-    provider: str = "openai", model_name: str = "o1"
+    provider: str, model_name: str
 ) -> BaseChatModel:
     """Initialize an expert language model client based on the specified provider and model."""
     return create_llm_client(provider, model_name, temperature=None, is_expert=True)

--- a/ra_aid/tools/expert.py
+++ b/ra_aid/tools/expert.py
@@ -17,8 +17,9 @@ def get_model():
     global _model
     try:
         if _model is None:
-            provider = _global_memory["config"]["expert_provider"] or "openai"
-            model = _global_memory["config"]["expert_model"] or "o1"
+            config = _global_memory["config"]
+            provider = config.get("expert_provider") or config.get("provider")
+            model = config.get("expert_model") or config.get("model")
             _model = initialize_expert_llm(provider, model)
     except Exception as e:
         _model = None

--- a/tests/ra_aid/test_llm.py
+++ b/tests/ra_aid/test_llm.py
@@ -50,9 +50,9 @@ def mock_openai():
 
 
 def test_initialize_expert_defaults(clean_env, mock_openai, monkeypatch):
-    """Test expert LLM initialization with default parameters."""
+    """Test expert LLM initialization with explicit parameters."""
     monkeypatch.setenv("EXPERT_OPENAI_API_KEY", "test-key")
-    _llm = initialize_expert_llm()
+    _llm = initialize_expert_llm("openai", "o1")
 
     mock_openai.assert_called_once_with(api_key="test-key", model="o1")
 


### PR DESCRIPTION
Discovered when using solely Ollama provider expert defaults to openai and o1 model.
This results in errors stating model o1 is not found, which is correct since the user never provided it.
 This change removes a default O1 usage and sets expert provider and model to match provided values.

```
# commands that show the problem and used to validate the fix
export OLLAMA_MODEL=phi3:3.8b
export OPENAI_API_BASE=http://localhost:11434/v1
export OPENAI_API_KEY=ollama
ra-aid --verbose --cowboy-mode --provider openai-compatible --model ${OLLAMA_MODEL} -m "What is this project about?"
```

This is the error that this PR resolves.

<img width="1132" alt="Screenshot 2025-02-08 at 1 52 13 PM" src="https://github.com/user-attachments/assets/69cb0b92-1471-41e6-a51a-a6c63f67b9f0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor  
  - Streamlined expert query configuration for a more intuitive setup. Users now need to explicitly specify essential options, ensuring clearer and more predictable behavior when working with expert queries.  
  - Improved provider selection logic enhances reliability and consistency in expert operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->