### PR TITLE
FEAT print config at the beginning

### DIFF
--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -304,22 +304,27 @@ def main():
                 sys.exit(1)
             logger.debug(f"Using default temperature {args.temperature} for model {args.model}")
 
-        # Display status line
+        # Display status lines
         status = Text()
-        status.append("🤖 ")  
+        # Model info
+        status.append("🤖 ")
         status.append(f"{args.provider}/{args.model}")
         if args.temperature is not None:
             status.append(f" @ T{args.temperature}")
+        status.append("\n")
 
+        # Expert info
+        status.append("🤔 ")
         if expert_enabled:
-            status.append(" | 🤔 ")
             status.append(f"{args.expert_provider}/{args.expert_model}")
         else:
-            status.append(" | 🤔 Expert: ")
+            status.append("Expert: ")
             status.append("Disabled", style="italic")
+        status.append("\n")
 
-        status.append(" | 🔍 Search: ")  
-        status.append("Enabled" if web_research_enabled else "Disabled", 
+        # Search info
+        status.append("🔍 Search: ")
+        status.append("Enabled" if web_research_enabled else "Disabled",
                      style=None if web_research_enabled else "italic")
         
         console.print(


### PR DESCRIPTION
There was a recent request to print configs at the beginning of the invocation.
This is a first pass and likely OK for now. We can expand over time if desired
<img width="1109" alt="Screenshot 2025-02-12 at 6 32 23 PM" src="https://github.com/user-attachments/assets/e792ab76-aa63-42ef-970f-6f949b49856c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced status display now provides additional details about model and expert configurations, including clear fallback messaging for disabled expert features.
  
- **Style**
  - Refined formatting has been applied to console outputs, such as updated styling for web research status and improved clarity in search information display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->