### PR TITLE
fix(env_inv.py): handle None values in sorting of installations

### DIFF
--- a/ra_aid/env_inv.py
+++ b/ra_aid/env_inv.py
@@ -319,7 +319,8 @@ class EnvDiscovery:
                     seen_paths.add(path)
                     ver = self._get_python_version(path)
                     installations.append({"version": ver, "path": path})
-        installations = sorted(installations, key=lambda x: x.get("version", ""))
+
+        installations = sorted(installations, key=lambda x: x.get("version", "") or "")
         self.results["python"]["installations"] = installations
 
     def _get_python_version(self, python_path):


### PR DESCRIPTION

- Fixes an error I was getting: 
```
in _detect_python 
.     installations = sorted(installations, key=lambda x: x.get("version", "")) 
.                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
. TypeError: '<' not supported between instances of 'NoneType' and 'str'  fix None type i guess f
. or installations.                                                                   
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the ordering of installation listings. The system now handles cases where version information is missing more consistently, ensuring a reliable display order. This fix provides a measurable enhancement to the overall ordering logic and improves user interaction with the installation list view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->