### PR TITLE
FIX Claude 3.7 Sonnet throws Expected thinking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ appmap.log
 *.swp
 /vsc/node_modules
 /vsc/dist
+cline_docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added model parameters for think tag support
 - Added comprehensive testing for think tag functionality
 - Added `--show-thoughts` flag to show thoughts of thinking models
+- Added `--disable-thinking` flag to disable thinking mode for Claude 3.7 Sonnet
+
+### Fixed
+- Fixed unretryable API error (400) when using Claude 3.7 Sonnet with thinking mode enabled for extended periods
+- Improved message formatting for Claude 3.7 Sonnet to ensure thinking blocks are properly included
 
 ### Changed
 - Updated langchain/langgraph deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added comprehensive testing for think tag functionality
 - Added `--show-thoughts` flag to show thoughts of thinking models
 - Added `--disable-thinking` flag to disable thinking mode for Claude 3.7 Sonnet
+- Added automatic workaround for Claude 3.7 Sonnet thinking block errors
+- Added `--skip-sonnet37-workaround` flag to opt out of automatic error handling
 
 ### Fixed
 - Fixed unretryable API error (400) when using Claude 3.7 Sonnet with thinking mode enabled for extended periods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added model parameters for think tag support
 - Added comprehensive testing for think tag functionality
 - Added `--show-thoughts` flag to show thoughts of thinking models
-- Added `--disable-thinking` flag to disable thinking mode for Claude 3.7 Sonnet
 - Added automatic workaround for Claude 3.7 Sonnet thinking block errors
 - Added `--skip-sonnet37-workaround` flag to opt out of automatic error handling
 

--- a/docs/docs/configuration/thinking-models.md
+++ b/docs/docs/configuration/thinking-models.md
@@ -105,13 +105,37 @@ RA.Aid configures the model to use its native thinking mode, and then processes 
 
 If you run RA.Aid without the `--show-thoughts` flag, the thinking content is still extracted from the model responses, but it won't be displayed in the console. This gives you a cleaner output focused only on the model's final responses.
 
-## Disabling Thinking Mode
+## Automatic Error Handling for Claude 3.7 Thinking Mode
 
-In some cases, you might want to disable the thinking mode feature for Claude 3.7 models, particularly if you're experiencing API errors or if you prefer the model to operate without the thinking capability.
+RA.Aid includes an automatic workaround for a known issue with Claude 3.7 Sonnet's thinking mode. When using Claude 3.7 Sonnet for extended periods (typically more than 10 minutes), you might encounter an unretryable API error (400) related to thinking blocks:
 
-### Using the disable_thinking Configuration Option
+```
+Unretryable API error: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'messages.1.content.0.type: Expected thinking or redacted_thinking, but found text...'}}
+```
 
-RA.Aid provides a `disable_thinking` configuration option that allows you to turn off the thinking mode for Claude 3.7 models:
+### Automatic Workaround
+
+When RA.Aid detects this specific error:
+
+1. It automatically disables thinking mode for Claude 3.7 Sonnet
+2. It continues the session without interruption
+3. It logs a warning message about the workaround being applied
+
+This automatic behavior ensures that your session continues smoothly even if the thinking block error occurs, without requiring manual intervention.
+
+### Opting Out of the Automatic Workaround
+
+If you prefer to handle these errors differently or want to maintain thinking mode at all costs, you can opt out of the automatic workaround using the `--skip-sonnet37-workaround` flag:
+
+```bash
+ra-aid -m "Debug the database connection issue" --provider anthropic --model claude-3-7-sonnet-20250219 --skip-sonnet37-workaround
+```
+
+When this flag is used, RA.Aid will not automatically disable thinking mode when the error occurs, and will instead crash with the unretryable API error.
+
+### Manually Disabling Thinking Mode
+
+You can also choose to disable thinking mode from the start using the `--disable-thinking` flag:
 
 ```bash
 ra-aid -m "Debug the database connection issue" --provider anthropic --model claude-3-7-sonnet-20250219 --disable-thinking
@@ -125,12 +149,11 @@ When this option is enabled:
 
 ### When to Disable Thinking Mode
 
-Consider disabling thinking mode in the following scenarios:
+Consider manually disabling thinking mode in the following scenarios:
 
-1. **API Errors**: If you encounter unretryable API errors (400) related to thinking blocks
-2. **Long-Running Sessions**: For extended sessions that run for more than 10 minutes
-3. **Performance Concerns**: If you need faster responses and don't require the thinking content
-4. **Compatibility Issues**: If you're using tools or workflows that aren't fully compatible with thinking mode
+1. **Long-Running Sessions**: For extended sessions that you know will run for more than 10 minutes
+2. **Performance Concerns**: If you need faster responses and don't require the thinking content
+3. **Compatibility Issues**: If you're using tools or workflows that aren't fully compatible with thinking mode
 
 ## Troubleshooting and Best Practices
 

--- a/docs/docs/configuration/thinking-models.md
+++ b/docs/docs/configuration/thinking-models.md
@@ -135,17 +135,12 @@ When this flag is used, RA.Aid will not automatically disable thinking mode when
 
 ### Manually Disabling Thinking Mode
 
-You can also choose to disable thinking mode from the start using the `--disable-thinking` flag:
+When the automatic workaround is applied, thinking mode is disabled for the current session. If you want to disable thinking mode from the start of a session, you can simply use a model that doesn't support thinking mode, such as Claude 3.5 Sonnet.
 
-```bash
-ra-aid -m "Debug the database connection issue" --provider anthropic --model claude-3-7-sonnet-20250219 --disable-thinking
-```
-
-When this option is enabled:
-
-- The thinking mode will not be activated for Claude 3.7 models
-- The model will operate in standard mode without the structured thinking blocks
-- This can help avoid certain API errors that might occur with thinking mode enabled
+This approach:
+- Prevents the thinking mode from being activated
+- Makes the model operate in standard mode without the structured thinking blocks
+- Avoids the API errors that can occur with thinking mode enabled
 
 ### When to Disable Thinking Mode
 
@@ -177,8 +172,8 @@ Unretryable API error: Error code: 400 - {'type': 'error', 'error': {'type': 'in
 
 This is related to the thinking mode format requirements. You can:
 
-- Use the `--disable-thinking` flag to turn off thinking mode
-- Upgrade to the latest version of RA.Aid which includes fixes for these errors
+- Use a model that doesn't support thinking mode, such as Claude 3.5 Sonnet
+- Upgrade to the latest version of RA.Aid which includes the automatic workaround for these errors
 - For long-running sessions, consider restarting the assistant periodically
 
 #### Excessive or irrelevant thinking

--- a/docs/docs/configuration/thinking-models.md
+++ b/docs/docs/configuration/thinking-models.md
@@ -105,6 +105,33 @@ RA.Aid configures the model to use its native thinking mode, and then processes 
 
 If you run RA.Aid without the `--show-thoughts` flag, the thinking content is still extracted from the model responses, but it won't be displayed in the console. This gives you a cleaner output focused only on the model's final responses.
 
+## Disabling Thinking Mode
+
+In some cases, you might want to disable the thinking mode feature for Claude 3.7 models, particularly if you're experiencing API errors or if you prefer the model to operate without the thinking capability.
+
+### Using the disable_thinking Configuration Option
+
+RA.Aid provides a `disable_thinking` configuration option that allows you to turn off the thinking mode for Claude 3.7 models:
+
+```bash
+ra-aid -m "Debug the database connection issue" --provider anthropic --model claude-3-7-sonnet-20250219 --disable-thinking
+```
+
+When this option is enabled:
+
+- The thinking mode will not be activated for Claude 3.7 models
+- The model will operate in standard mode without the structured thinking blocks
+- This can help avoid certain API errors that might occur with thinking mode enabled
+
+### When to Disable Thinking Mode
+
+Consider disabling thinking mode in the following scenarios:
+
+1. **API Errors**: If you encounter unretryable API errors (400) related to thinking blocks
+2. **Long-Running Sessions**: For extended sessions that run for more than 10 minutes
+3. **Performance Concerns**: If you need faster responses and don't require the thinking content
+4. **Compatibility Issues**: If you're using tools or workflows that aren't fully compatible with thinking mode
+
 ## Troubleshooting and Best Practices
 
 ### Common Issues
@@ -116,6 +143,20 @@ If you're not seeing thinking content despite using the `--show-thoughts` flag:
 - Ensure you're using a model that supports thinking (qwen-qwq-32b or claude-3-7-sonnet-20250219)
 - Verify that the model is properly configured in your environment
 - Check that the model is actually including thinking content in its responses (not all prompts will generate thinking)
+
+#### API errors with Claude 3.7 Sonnet
+
+If you encounter errors like:
+
+```
+Unretryable API error: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'messages.1.content.0.type: Expected thinking or redacted_thinking, but found text...'}}
+```
+
+This is related to the thinking mode format requirements. You can:
+
+- Use the `--disable-thinking` flag to turn off thinking mode
+- Upgrade to the latest version of RA.Aid which includes fixes for these errors
+- For long-running sessions, consider restarting the assistant periodically
 
 #### Excessive or irrelevant thinking
 
@@ -137,4 +178,3 @@ For the most effective use of thinking models:
 4. **Compare thinking with output**: Use the thinking content to evaluate the quality of the model's reasoning and identify potential flaws in its approach.
 
 5. **Provide clear instructions**: When the model's thinking seems off-track, provide clearer instructions in your next prompt to guide its reasoning process.
-

--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -291,6 +291,11 @@ Examples:
         help="Display model thinking content extracted from think tags when supported by the model",
     )
     parser.add_argument(
+        "--skip-sonnet37-workaround",
+        action="store_true",
+        help="Skip automatic workaround for Claude 3.7 Sonnet thinking block errors",
+    )
+    parser.add_argument(
         "--reasoning-assistance",
         action="store_true",
         help="Force enable reasoning assistance regardless of model defaults",

--- a/ra_aid/agent_utils.py
+++ b/ra_aid/agent_utils.py
@@ -697,22 +697,21 @@ def run_agent_with_retry(
                     return f"Agent has crashed: {crash_message}"
 
                 try:
-                    # Ensure messages have thinking blocks if needed before each run
+                    # Check if we need to ensure thinking blocks
                     config = get_config_repository().get_all()
-                    if is_anthropic_claude(config):
-                        provider = config.get("provider", "")
-                        model_name = config.get("model", "")
+                    provider = config.get("provider", "")
+                    model_name = config.get("model", "")
+                    
+                    # Only apply to Claude 3.7 models with thinking enabled
+                    if (provider.lower() == "anthropic" and 
+                        "claude-3-7" in model_name.lower() and 
+                        not config.get("disable_thinking", False)):
                         
-                        # Only apply to Claude 3.7 models with thinking enabled
-                        if (provider.lower() == "anthropic" and 
-                            "claude-3-7" in model_name.lower() and 
-                            not config.get("disable_thinking", False)):
-                            
-                            # Get model configuration to check if thinking is supported
-                            model_config = models_params.get(provider, {}).get(model_name, {})
-                            if model_config.get("supports_thinking", False):
-                                logger.debug("Ensuring thinking blocks for Claude 3.7 before agent run")
-                                msg_list = _ensure_thinking_block(msg_list, config)
+                        # Get model configuration to check if thinking is supported
+                        model_config = models_params.get(provider, {}).get(model_name, {})
+                        if model_config.get("supports_thinking", False):
+                            logger.debug("Ensuring thinking blocks for Claude 3.7 before agent run")
+                            msg_list = _ensure_thinking_block(msg_list, config)
                     
                     _run_agent_stream(agent, msg_list)
                     if fallback_handler:

--- a/ra_aid/llm.py
+++ b/ra_aid/llm.py
@@ -259,7 +259,7 @@ def create_llm_client(
     else:
         temp_kwargs = {}
 
-    if supports_thinking:
+    if supports_thinking and not config.get("disable_thinking", False):
         temp_kwargs = {"thinking": {"type": "enabled", "budget_tokens": 12000}}
 
     if provider == "deepseek":

--- a/ra_aid/llm.py
+++ b/ra_aid/llm.py
@@ -259,6 +259,7 @@ def create_llm_client(
     else:
         temp_kwargs = {}
 
+    # Enable thinking mode for models that support it, unless it's been disabled by the automatic workaround
     if supports_thinking and not config.get("disable_thinking", False):
         temp_kwargs = {"thinking": {"type": "enabled", "budget_tokens": 12000}}
 

--- a/tests/ra_aid/test_disable_thinking.py
+++ b/tests/ra_aid/test_disable_thinking.py
@@ -55,6 +55,18 @@ class TestDisableThinking:
                 {},
                 "Non-Claude model should not have thinking param",
             ),
+            # Test case 5: Claude 3.7 model with skip_sonnet37_workaround enabled
+            (
+                "skip_sonnet37_workaround",
+                {
+                    "provider": "anthropic",
+                    "model": "claude-3-7-sonnet-20250219",
+                    "skip_sonnet37_workaround": True,
+                },
+                {"supports_thinking": True},
+                {"thinking": {"type": "enabled", "budget_tokens": 12000}},
+                "Claude 3.7 with skip_sonnet37_workaround=True should still have thinking param",
+            ),
         ],
     )
     def test_disable_thinking_option(

--- a/tests/ra_aid/test_disable_thinking.py
+++ b/tests/ra_aid/test_disable_thinking.py
@@ -1,0 +1,103 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from ra_aid.llm import create_llm_client
+
+
+class TestDisableThinking:
+    """Test suite for the disable_thinking configuration option."""
+
+    @pytest.mark.parametrize(
+        "test_id, config, model_config, expected_thinking_param, description",
+        [
+            # Test case 1: Claude 3.7 model with thinking enabled (default)
+            (
+                "claude_thinking_enabled",
+                {
+                    "provider": "anthropic",
+                    "model": "claude-3-7-sonnet-20250219",
+                },
+                {"supports_thinking": True},
+                {"thinking": {"type": "enabled", "budget_tokens": 12000}},
+                "Claude 3.7 should have thinking enabled by default",
+            ),
+            # Test case 2: Claude 3.7 model with thinking explicitly disabled
+            (
+                "claude_thinking_disabled",
+                {
+                    "provider": "anthropic",
+                    "model": "claude-3-7-sonnet-20250219",
+                    "disable_thinking": True,
+                },
+                {"supports_thinking": True},
+                {},
+                "Claude 3.7 with disable_thinking=True should not have thinking param",
+            ),
+            # Test case 3: Non-thinking model should not have thinking param
+            (
+                "non_thinking_model",
+                {
+                    "provider": "anthropic",
+                    "model": "claude-3-5-sonnet-20240620",
+                },
+                {"supports_thinking": False},
+                {},
+                "Non-thinking model should not have thinking param",
+            ),
+            # Test case 4: Non-Claude model should not have thinking param
+            (
+                "non_claude_model",
+                {
+                    "provider": "openai",
+                    "model": "gpt-4",
+                },
+                {},
+                {},
+                "Non-Claude model should not have thinking param",
+            ),
+        ],
+    )
+    def test_disable_thinking_option(
+        self, test_id, config, model_config, expected_thinking_param, description
+    ):
+        """Test that the disable_thinking option correctly controls thinking mode."""
+        # Mock the necessary dependencies
+        with patch("ra_aid.llm.ChatAnthropic") as mock_anthropic:
+            with patch("ra_aid.llm.ChatOpenAI") as mock_openai:
+                with patch("ra_aid.llm.models_params") as mock_models_params:
+                    # Set up the mock to return the specified model_config
+                    mock_models_params.get.return_value = {config["model"]: model_config}
+                    
+                    # Set up the mock for get_provider_config
+                    with patch("ra_aid.llm.get_provider_config") as mock_get_provider_config:
+                        # Include disable_thinking in the provider config if it's in the test config
+                        provider_config = {
+                            "api_key": "test-key",
+                            "base_url": None,
+                        }
+                        if "disable_thinking" in config:
+                            provider_config["disable_thinking"] = config["disable_thinking"]
+                        
+                        mock_get_provider_config.return_value = provider_config
+                        
+                        # Call the function without passing disable_thinking directly
+                        create_llm_client(
+                            config["provider"],
+                            config["model"],
+                            temperature=None,
+                            is_expert=False
+                        )
+                        
+                        # Check if the correct parameters were passed
+                        if config["provider"] == "anthropic":
+                            # Get the kwargs passed to ChatAnthropic
+                            _, kwargs = mock_anthropic.call_args
+                            
+                            # Check if thinking param was included or not
+                            if expected_thinking_param:
+                                assert "thinking" in kwargs, f"Test {test_id} failed: {description}"
+                                assert kwargs["thinking"] == expected_thinking_param["thinking"], \
+                                    f"Test {test_id} failed: Thinking param doesn't match expected value"
+                            else:
+                                assert "thinking" not in kwargs, \
+                                    f"Test {test_id} failed: Thinking param should not be present"

--- a/tests/ra_aid/test_ensure_thinking_block.py
+++ b/tests/ra_aid/test_ensure_thinking_block.py
@@ -1,0 +1,145 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from ra_aid.agent_utils import _ensure_thinking_block
+
+
+class TestEnsureThinkingBlock:
+    """Test suite for the _ensure_thinking_block function."""
+
+    @pytest.mark.parametrize(
+        "test_id, messages, config, expected_changes, description",
+        [
+            # Test case 1: Non-Claude 3.7 model should not modify messages
+            (
+                "non_claude_model",
+                [
+                    HumanMessage(content="Hello"),
+                    AIMessage(content=[{"type": "text", "text": "Hi there"}]),
+                ],
+                {"provider": "openai", "model": "gpt-4"},
+                False,
+                "Non-Claude 3.7 model should not modify messages",
+            ),
+            # Test case 2: Claude 3.7 model with thinking disabled should not modify messages
+            (
+                "claude_thinking_disabled",
+                [
+                    HumanMessage(content="Hello"),
+                    AIMessage(content=[{"type": "text", "text": "Hi there"}]),
+                ],
+                {
+                    "provider": "anthropic",
+                    "model": "claude-3-7-sonnet-20250219",
+                    "disable_thinking": True,
+                },
+                False,
+                "Claude 3.7 with thinking disabled should not modify messages",
+            ),
+            # Test case 3: Claude 3.7 model with thinking enabled but no AI messages should not modify messages
+            (
+                "claude_no_ai_messages",
+                [
+                    HumanMessage(content="Hello"),
+                    SystemMessage(content="System message"),
+                ],
+                {"provider": "anthropic", "model": "claude-3-7-sonnet-20250219"},
+                False,
+                "Claude 3.7 with no AI messages should not modify messages",
+            ),
+            # Test case 4: Claude 3.7 model with thinking enabled and AI message with text content should log warning
+            (
+                "claude_ai_text_content",
+                [
+                    HumanMessage(content="Hello"),
+                    AIMessage(content="Text response"),
+                ],
+                {"provider": "anthropic", "model": "claude-3-7-sonnet-20250219"},
+                False,
+                "Claude 3.7 with AI message with text content should log warning",
+            ),
+            # Test case 5: Claude 3.7 model with thinking enabled and AI message with list content but no thinking block
+            (
+                "claude_ai_no_thinking_block",
+                [
+                    HumanMessage(content="Hello"),
+                    AIMessage(content=[{"type": "text", "text": "Hi there"}]),
+                ],
+                {"provider": "anthropic", "model": "claude-3-7-sonnet-20250219"},
+                True,
+                "Claude 3.7 with AI message without thinking block should add one",
+            ),
+            # Test case 6: Claude 3.7 model with thinking enabled and AI message with list content with thinking block
+            (
+                "claude_ai_with_thinking_block",
+                [
+                    HumanMessage(content="Hello"),
+                    AIMessage(
+                        content=[
+                            {"type": "thinking", "thinking": "Let me think..."},
+                            {"type": "text", "text": "Hi there"},
+                        ]
+                    ),
+                ],
+                {"provider": "anthropic", "model": "claude-3-7-sonnet-20250219"},
+                False,
+                "Claude 3.7 with AI message with thinking block should not modify it",
+            ),
+            # Test case 7: Claude 3.7 model with thinking enabled and multiple AI messages
+            (
+                "claude_multiple_ai_messages",
+                [
+                    HumanMessage(content="Hello"),
+                    AIMessage(content=[{"type": "text", "text": "First response"}]),
+                    HumanMessage(content="Follow-up"),
+                    AIMessage(content=[{"type": "text", "text": "Second response"}]),
+                ],
+                {"provider": "anthropic", "model": "claude-3-7-sonnet-20250219"},
+                True,
+                "Claude 3.7 with multiple AI messages should add thinking blocks to all",
+            ),
+        ],
+    )
+    def test_ensure_thinking_block(
+        self, test_id, messages, config, expected_changes, description
+    ):
+        """Test the _ensure_thinking_block function with various inputs."""
+        # Mock the logger
+        with patch("ra_aid.agent_utils.logger") as mock_logger:
+            # Mock the models_params dictionary
+            with patch("ra_aid.agent_utils.models_params") as mock_models_params:
+                # Set up the mock to return supports_thinking=True for Claude 3.7 models
+                if "claude-3-7" in config.get("model", ""):
+                    mock_models_params.get.return_value = {
+                        config["model"]: {"supports_thinking": True}
+                    }
+                else:
+                    mock_models_params.get.return_value = {}
+
+                # Make a copy of the original messages for comparison
+                original_messages = [
+                    AIMessage(content=msg.content) if isinstance(msg, AIMessage) else msg
+                    for msg in messages
+                ]
+
+                # Call the function
+                result = _ensure_thinking_block(messages, config)
+
+                # Check if the result is different from the input when expected
+                if expected_changes:
+                    assert result != original_messages, f"Test {test_id} failed: {description}"
+                    
+                    # Check that AI messages have thinking blocks
+                    for msg in result:
+                        if hasattr(msg, "type") and msg.type == "ai":
+                            if isinstance(msg.content, list) and len(msg.content) > 0:
+                                assert msg.content[0].get("type") == "thinking" or msg.content[0].get("type") == "redacted_thinking", \
+                                    f"Test {test_id} failed: AI message should have thinking block"
+                else:
+                    # Check that the messages were not modified
+                    assert result == messages, f"Test {test_id} failed: {description}"
+
+                # Check for warning logs for text content
+                if "claude_ai_text_content" == test_id:
+                    mock_logger.warning.assert_called_once()

--- a/tests/ra_aid/test_sonnet37_workaround.py
+++ b/tests/ra_aid/test_sonnet37_workaround.py
@@ -1,0 +1,144 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from ra_aid.agent_utils import run_agent_with_retry
+from ra_aid.agent_context import reset_completion_flags
+
+
+# Create a mock APIError class for testing
+class MockAPIError(Exception):
+    """Mock version of Anthropic's APIError for testing."""
+    pass
+
+
+class TestSonnet37Workaround:
+    """Test suite for the automatic Claude 3.7 Sonnet thinking block error workaround."""
+
+    def test_automatic_workaround_applied(self):
+        """Test that the workaround is automatically applied when the specific error occurs."""
+        # Mock dependencies
+        mock_agent = MagicMock()
+        
+        # Create a mock error that simulates the thinking block error
+        thinking_error = MockAPIError("400 Bad Request: messages.1.content.0.type: Expected thinking or redacted_thinking, but found text")
+        
+        # Set up the run_agent_stream to first raise the error, then succeed
+        mock_run_stream = MagicMock()
+        mock_run_stream.side_effect = [
+            thinking_error,  # First call raises error
+            None,  # Second call succeeds
+        ]
+        
+        # Mock config repository
+        mock_config = {
+            "provider": "anthropic",
+            "model": "claude-3-7-sonnet-20250219",
+        }
+        
+        with patch("ra_aid.agent_utils.APIError", MockAPIError):
+            with patch("ra_aid.agent_utils.get_config_repository") as mock_get_config:
+                # Create a mock repository that returns our test config
+                mock_repo = MagicMock()
+                mock_repo.get_all.return_value = mock_config
+                mock_repo.get.side_effect = lambda key, default=None: mock_config.get(key, default)
+                mock_repo.set = MagicMock()
+                mock_get_config.return_value = mock_repo
+                
+                # Mock other dependencies to prevent actual execution
+                with patch("ra_aid.agent_utils._run_agent_stream", side_effect=mock_run_stream.side_effect):
+                    with patch("ra_aid.agent_utils._execute_test_command_wrapper") as mock_test_cmd:
+                        # Mock the test command wrapper to return a tuple indicating success
+                        mock_test_cmd.return_value = (True, "", False, 0)  # (should_break, prompt, auto_test, test_attempts)
+                        
+                        # Run the function
+                        result = run_agent_with_retry(mock_agent, "Test prompt")
+                        
+                        # Verify the workaround was applied
+                        mock_repo.set.assert_any_call("disable_thinking", True)
+                        
+                        # The result might be None since we're mocking _run_agent_stream
+                        # Just verify that the workaround was applied
+                        assert mock_repo.set.call_count > 0
+
+    def test_skip_sonnet37_workaround(self):
+        """Test that the workaround is not applied when skip_sonnet37_workaround is True."""
+        # Mock dependencies
+        mock_agent = MagicMock()
+        
+        # Create a mock error that simulates the thinking block error
+        thinking_error = MockAPIError("400 Bad Request: messages.1.content.0.type: Expected thinking or redacted_thinking, but found text")
+        
+        # Set up the run_agent_stream to raise the error
+        mock_run_stream = MagicMock()
+        mock_run_stream.side_effect = thinking_error
+        
+        # Mock config repository with skip_sonnet37_workaround=True
+        mock_config = {
+            "provider": "anthropic",
+            "model": "claude-3-7-sonnet-20250219",
+            "skip_sonnet37_workaround": True,
+        }
+        
+        with patch("ra_aid.agent_utils.APIError", MockAPIError):
+            with patch("ra_aid.agent_utils.get_config_repository") as mock_get_config:
+                # Create a mock repository that returns our test config
+                mock_repo = MagicMock()
+                mock_repo.get_all.return_value = mock_config
+                mock_repo.get.side_effect = lambda key, default=None: mock_config.get(key, default)
+                mock_get_config.return_value = mock_repo
+                
+                # Mock agent_context.mark_agent_crashed to verify it's called
+                with patch("ra_aid.agent_context.mark_agent_crashed") as mock_mark_crashed:
+                    # Mock other dependencies to prevent actual execution
+                    with patch("ra_aid.agent_utils._run_agent_stream", side_effect=mock_run_stream.side_effect):
+                        
+                        # Run the function - should crash with unretryable error
+                        result = run_agent_with_retry(mock_agent, "Test prompt")
+                        
+                        # Verify the agent was marked as crashed
+                        mock_mark_crashed.assert_called_once()
+                        
+                        # Verify the function returned a crash message
+                        assert "Agent has crashed" in result
+                        assert "Unretryable API error" in result
+
+    def test_non_thinking_error_not_handled(self):
+        """Test that other 400 errors are not handled by the workaround."""
+        # Mock dependencies
+        mock_agent = MagicMock()
+        
+        # Create a mock error that simulates a different 400 error
+        other_error = MockAPIError("400 Bad Request: Some other error message")
+        
+        # Set up the run_agent_stream to raise the error
+        mock_run_stream = MagicMock()
+        mock_run_stream.side_effect = other_error
+        
+        # Mock config repository
+        mock_config = {
+            "provider": "anthropic",
+            "model": "claude-3-7-sonnet-20250219",
+        }
+        
+        with patch("ra_aid.agent_utils.APIError", MockAPIError):
+            with patch("ra_aid.agent_utils.get_config_repository") as mock_get_config:
+                # Create a mock repository that returns our test config
+                mock_repo = MagicMock()
+                mock_repo.get_all.return_value = mock_config
+                mock_repo.get.side_effect = lambda key, default=None: mock_config.get(key, default)
+                mock_get_config.return_value = mock_repo
+                
+                # Mock agent_context.mark_agent_crashed to verify it's called
+                with patch("ra_aid.agent_context.mark_agent_crashed") as mock_mark_crashed:
+                    # Mock other dependencies to prevent actual execution
+                    with patch("ra_aid.agent_utils._run_agent_stream", side_effect=mock_run_stream.side_effect):
+                        
+                        # Run the function - should crash with unretryable error
+                        result = run_agent_with_retry(mock_agent, "Test prompt")
+                        
+                        # Verify the agent was marked as crashed
+                        mock_mark_crashed.assert_called_once()
+                        
+                        # Verify the function returned a crash message
+                        assert "Agent has crashed" in result
+                        assert "Unretryable API error" in result

--- a/tests/ra_aid/test_thinking_integration.py
+++ b/tests/ra_aid/test_thinking_integration.py
@@ -1,0 +1,91 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from langchain_core.messages import AIMessage, HumanMessage
+from ra_aid.agent_utils import run_agent_with_retry
+
+
+class TestThinkingIntegration:
+    """Test suite for the integration of thinking block functionality in run_agent_with_retry."""
+
+    @pytest.mark.parametrize(
+        "test_id, config, model_name, should_ensure_thinking, description",
+        [
+            # Test case 1: Claude 3.7 model with thinking enabled should ensure thinking blocks
+            (
+                "claude_thinking_enabled",
+                {
+                    "provider": "anthropic",
+                    "model": "claude-3-7-sonnet-20250219",
+                },
+                "claude-3-7-sonnet-20250219",
+                True,
+                "Claude 3.7 should ensure thinking blocks",
+            ),
+            # Test case 2: Claude 3.7 model with thinking disabled should not ensure thinking blocks
+            (
+                "claude_thinking_disabled",
+                {
+                    "provider": "anthropic",
+                    "model": "claude-3-7-sonnet-20250219",
+                    "disable_thinking": True,
+                },
+                "claude-3-7-sonnet-20250219",
+                False,
+                "Claude 3.7 with thinking disabled should not ensure thinking blocks",
+            ),
+            # Test case 3: Non-Claude 3.7 model should not ensure thinking blocks
+            (
+                "non_claude_model",
+                {
+                    "provider": "openai",
+                    "model": "gpt-4",
+                },
+                "gpt-4",
+                False,
+                "Non-Claude model should not ensure thinking blocks",
+            ),
+        ],
+    )
+    def test_run_agent_with_retry_thinking_integration(
+        self, test_id, config, model_name, should_ensure_thinking, description
+    ):
+        """Test that run_agent_with_retry correctly integrates thinking block functionality."""
+        # Mock the necessary dependencies
+        with patch("ra_aid.agent_utils.get_config_repository") as mock_get_config:
+            with patch("ra_aid.agent_utils._ensure_thinking_block") as mock_ensure_thinking:
+                with patch("ra_aid.agent_utils._run_agent_stream") as mock_run_agent_stream:
+                    with patch("ra_aid.agent_utils._setup_interrupt_handling") as mock_setup:
+                        with patch("ra_aid.agent_utils._restore_interrupt_handling"):
+                            with patch("ra_aid.agent_utils.agent_context"):
+                                with patch("ra_aid.agent_utils.InterruptibleSection"):
+                                    with patch("ra_aid.agent_utils.is_anthropic_claude") as mock_is_anthropic:
+                                        with patch("ra_aid.agent_utils.models_params") as mock_models_params:
+                                            # Set up the mocks
+                                            mock_get_config.return_value.get_all.return_value = config
+                                            mock_get_config.return_value.get.return_value = False
+                                            mock_setup.return_value = None
+                                            mock_run_agent_stream.return_value = True
+                                            
+                                            # Set up is_anthropic_claude to return True for Claude models
+                                            mock_is_anthropic.return_value = "claude" in model_name.lower()
+                                            
+                                            # Set up models_params to return supports_thinking=True for Claude 3.7 models
+                                            if "claude-3-7" in model_name:
+                                                mock_models_params.get.return_value = {
+                                                    model_name: {"supports_thinking": True}
+                                                }
+                                            else:
+                                                mock_models_params.get.return_value = {}
+                                            
+                                            # Create a mock agent
+                                            mock_agent = MagicMock()
+                                            
+                                            # Call the function
+                                            run_agent_with_retry(mock_agent, "Test prompt")
+                                            
+                                            # Check if _ensure_thinking_block was called correctly
+                                            if should_ensure_thinking:
+                                                mock_ensure_thinking.assert_called()
+                                            else:
+                                                mock_ensure_thinking.assert_not_called()


### PR DESCRIPTION
Fix #115 
This PR is WIP, which is the initial commit while considering the current approach.

Thought 1: The current implementation leaves it up to the user to set the flag. I could update the code to disable thinking if the error appears and it's a sonnet model. This alternate approach would be automatic but would mean experiencing the error at least once. Undecided.

Thought 2: Made the check automatic instead of expecting the user to provide the --disable-thinking flag. There is still an issue from the raised issue when the context is exceeded. I'm skeptical that handling that scenario should be in this PR; therefore, I've not tackled it. I think handling the scenario where the context is exceeded might warrant its own independent discussion.

Thought 3: While this PR has many unit tests, I have not tried the code since Im not sure I have a code base or scenario to test this issue. Maybe "get this code base to 100% code coverage" would make it take a long time, but its just a guess.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced command-line flag `--skip-sonnet37-workaround` for opting out of automatic error handling related to the Claude 3.7 Sonnet model.
  - Added a new section in the documentation detailing automatic error handling for Claude 3.7 thinking mode.

- **Bug Fixes**
  - Resolved an unretryable API error (400) that occurred when using thinking mode for extended periods.
  - Improved message formatting to ensure proper inclusion of thinking blocks in output.

- **Documentation**
  - Updated user documentation with a new section on automatic error handling and guidelines for disabling thinking mode.

- **Tests**
  - Introduced new test suites to validate the behavior of thinking mode controls and error handling mechanisms across various configurations.
  - Added tests for the automatic workaround for thinking block errors and its configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->