### PR TITLE
Fix dev dependencies instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ source venv/bin/activate  # On Windows use `venv\Scripts\activate`
 
 3. Install development dependencies:
 ```bash
-pip install -r requirements-dev.txt
+pip install -e ".[dev]"
 ```
 
 4. Run tests:


### PR DESCRIPTION
I tried to follow the instructions and they failed when I executed the tests.

This instruction seems to be the culrprit:
```
pip install -r requirements-dev.txt
```

This only installs some core test dependencies (pytest, etc.) but there's a lot missing in order to make the tests run successfully. This worked for me:

```
pip install -e ".[dev]"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

These release notes detail improvements to the project’s documentation that enhance the development setup:

- **Documentation**
  - Updated installation instructions to streamline dependency management.
  - The revised guidance provides a more efficient and user-friendly process for setting up the development environment, ensuring a smoother experience during the development setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->