### PR TITLE
Fix Sonnet 3.7 Token Limiter - Adjust Effective Max Input Tokens

### DIFF
--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -5,23 +5,7 @@ import sys
 import uuid
 from datetime import datetime
 
-# Add litellm import
 import litellm
-
-# Configure litellm to suppress debug logs
-os.environ["LITELLM_LOG"] = "ERROR"
-litellm.suppress_debug_info = True
-litellm.set_verbose = False
-
-# Explicitly configure LiteLLM's loggers
-for logger_name in ["litellm", "LiteLLM"]:
-    litellm_logger = logging.getLogger(logger_name)
-    litellm_logger.setLevel(logging.WARNING)
-    litellm_logger.propagate = True
-
-# Use litellm's internal method to disable debugging
-if hasattr(litellm, "_logging") and hasattr(litellm._logging, "_disable_debugging"):
-    litellm._logging._disable_debugging()
 
 from langgraph.checkpoint.memory import MemorySaver
 from rich.console import Console
@@ -98,6 +82,21 @@ from ra_aid.tool_configs import get_chat_tools, set_modification_tools
 from ra_aid.tools.human import ask_human
 
 logger = get_logger(__name__)
+
+# Configure litellm to suppress debug logs
+os.environ["LITELLM_LOG"] = "ERROR"
+litellm.suppress_debug_info = True
+litellm.set_verbose = False
+
+# Explicitly configure LiteLLM's loggers
+for logger_name in ["litellm", "LiteLLM"]:
+    litellm_logger = logging.getLogger(logger_name)
+    litellm_logger.setLevel(logging.WARNING)
+    litellm_logger.propagate = True
+
+# Use litellm's internal method to disable debugging
+if hasattr(litellm, "_logging") and hasattr(litellm._logging, "_disable_debugging"):
+    litellm._logging._disable_debugging()
 
 
 def launch_webui(host: str, port: int):

--- a/ra_aid/anthropic_token_limiter.py
+++ b/ra_aid/anthropic_token_limiter.py
@@ -1,24 +1,19 @@
 """Utilities for handling token limits with Anthropic models."""
 
 from functools import partial
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 from langchain_core.language_models import BaseChatModel
 from ra_aid.model_detection import is_claude_37
-from dataclasses import dataclass
 
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import (
-    AIMessage,
     BaseMessage,
-    RemoveMessage,
-    ToolMessage,
     trim_messages,
 )
 from langchain_core.messages.base import message_to_dict
 
 from ra_aid.anthropic_message_utils import (
     anthropic_trim_messages,
-    has_tool_use,
 )
 from langgraph.prebuilt.chat_agent_executor import AgentState
 from litellm import token_counter, get_model_info
@@ -27,7 +22,6 @@ from ra_aid.agent_backends.ciayn_agent import CiaynAgent
 from ra_aid.database.repositories.config_repository import get_config_repository
 from ra_aid.logging_config import get_logger
 from ra_aid.models_params import DEFAULT_TOKEN_LIMIT, models_params
-from ra_aid.console.output import cpm, print_messages_compact
 
 logger = get_logger(__name__)
 
@@ -170,6 +164,29 @@ def sonnet_35_state_modifier(
     return result
 
 
+def get_provider_and_model_for_agent_type(config: Dict[str, Any], agent_type: str) -> Tuple[str, str]:
+    """Get the provider and model name for the specified agent type.
+    
+    Args:
+        config: Configuration dictionary containing provider and model information
+        agent_type: Type of agent ("default", "research", or "planner")
+        
+    Returns:
+        Tuple[str, str]: A tuple containing (provider, model_name)
+    """
+    if agent_type == "research":
+        provider = config.get("research_provider", "") or config.get("provider", "")
+        model_name = config.get("research_model", "") or config.get("model", "")
+    elif agent_type == "planner":
+        provider = config.get("planner_provider", "") or config.get("provider", "")
+        model_name = config.get("planner_model", "") or config.get("model", "")
+    else:
+        provider = config.get("provider", "")
+        model_name = config.get("model", "")
+    
+    return provider, model_name
+
+
 def adjust_claude_37_token_limit(max_input_tokens: int, model: Optional[BaseChatModel]) -> Optional[int]:
     """Adjust token limit for Claude 3.7 models by subtracting max_tokens.
     
@@ -217,19 +234,13 @@ def get_model_token_limit(
             # In tests, this may fail because the repository isn't set up
             # So we'll use the passed config directly
             pass
-        if agent_type == "research":
-            provider = config.get("research_provider", "") or config.get("provider", "")
-            model_name = config.get("research_model", "") or config.get("model", "")
-        elif agent_type == "planner":
-            provider = config.get("planner_provider", "") or config.get("provider", "")
-            model_name = config.get("planner_model", "") or config.get("model", "")
-        else:
-            provider = config.get("provider", "")
-            model_name = config.get("model", "")
+            
+        provider, model_name = get_provider_and_model_for_agent_type(config, agent_type)
+
+        # Always attempt to get model info from litellm first
+        provider_model = model_name if not provider else f"{provider}/{model_name}"
 
         try:
-
-            provider_model = model_name if not provider else f"{provider}/{model_name}"
             model_info = get_model_info(provider_model)
             max_input_tokens = model_info.get("max_input_tokens")
             if max_input_tokens:

--- a/ra_aid/model_detection.py
+++ b/ra_aid/model_detection.py
@@ -1,0 +1,39 @@
+"""Utilities for detecting and working with specific model types."""
+
+from typing import Optional, Dict, Any
+
+
+def is_claude_37(model: str) -> bool:
+    """Check if the model is a Claude 3.7 model.
+    
+    Args:
+        model: The model name to check
+        
+    Returns:
+        bool: True if the model is a Claude 3.7 model, False otherwise
+    """
+    patterns = ["claude-3.7", "claude3.7", "claude-3-7"]
+    return any(pattern in model for pattern in patterns)
+
+
+def is_anthropic_claude(config: Dict[str, Any]) -> bool:
+    """Check if the provider and model name indicate an Anthropic Claude model.
+
+    Args:
+        config: Configuration dictionary containing provider and model information
+
+    Returns:
+        bool: True if this is an Anthropic Claude model
+    """
+    # For backwards compatibility, allow passing of config directly
+    provider = config.get("provider", "")
+    model_name = config.get("model", "")
+    result = (
+        provider.lower() == "anthropic"
+        and model_name
+        and "claude" in model_name.lower()
+    ) or (
+        provider.lower() == "openrouter"
+        and model_name.lower().startswith("anthropic/claude-")
+    )
+    return result

--- a/tests/ra_aid/test_agent_utils.py
+++ b/tests/ra_aid/test_agent_utils.py
@@ -13,8 +13,7 @@ from ra_aid.agent_context import (
 )
 from ra_aid.agent_utils import (
     AgentState,
-    create_agent,
-    is_anthropic_claude,
+    create_agent
 )
 from ra_aid.anthropic_token_limiter import (
     get_model_token_limit,
@@ -451,31 +450,6 @@ def test_handle_api_error_retry(monkeypatch):
     monkeypatch.setattr(time, "sleep", lambda s: None)
     # Should not raise error when attempt is lower than max retries
     _handle_api_error(Exception("error code 429"), 0, 5, 1)
-
-
-def test_is_anthropic_claude():
-    """Test is_anthropic_claude function with various configurations."""
-    # Test Anthropic provider cases
-    assert is_anthropic_claude({"provider": "anthropic", "model": "claude-2"})
-    assert is_anthropic_claude({"provider": "ANTHROPIC", "model": "claude-instant"})
-    assert not is_anthropic_claude({"provider": "anthropic", "model": "gpt-4"})
-
-    # Test OpenRouter provider cases
-    assert is_anthropic_claude(
-        {"provider": "openrouter", "model": "anthropic/claude-2"}
-    )
-    assert is_anthropic_claude(
-        {"provider": "openrouter", "model": "anthropic/claude-instant"}
-    )
-    assert not is_anthropic_claude({"provider": "openrouter", "model": "openai/gpt-4"})
-
-    # Test edge cases
-    assert not is_anthropic_claude({})  # Empty config
-    assert not is_anthropic_claude({"provider": "anthropic"})  # Missing model
-    assert not is_anthropic_claude({"model": "claude-2"})  # Missing provider
-    assert not is_anthropic_claude(
-        {"provider": "other", "model": "claude-2"}
-    )  # Wrong provider
 
 
 def test_run_agent_with_retry_checks_crash_status(monkeypatch, mock_config_repository):

--- a/tests/ra_aid/test_model_detection.py
+++ b/tests/ra_aid/test_model_detection.py
@@ -1,0 +1,50 @@
+"""Unit tests for model_detection.py."""
+
+import pytest
+from ra_aid.model_detection import is_anthropic_claude, is_claude_37
+
+
+def test_is_anthropic_claude():
+    """Test is_anthropic_claude function with various configurations."""
+    # Test Anthropic provider cases
+    assert is_anthropic_claude({"provider": "anthropic", "model": "claude-2"})
+    assert is_anthropic_claude({"provider": "ANTHROPIC", "model": "claude-instant"})
+    assert not is_anthropic_claude({"provider": "anthropic", "model": "gpt-4"})
+
+    # Test OpenRouter provider cases
+    assert is_anthropic_claude(
+        {"provider": "openrouter", "model": "anthropic/claude-2"}
+    )
+    assert is_anthropic_claude(
+        {"provider": "openrouter", "model": "anthropic/claude-instant"}
+    )
+    assert not is_anthropic_claude({"provider": "openrouter", "model": "openai/gpt-4"})
+
+    # Test edge cases
+    assert not is_anthropic_claude({})  # Empty config
+    assert not is_anthropic_claude({"provider": "anthropic"})  # Missing model
+    assert not is_anthropic_claude({"model": "claude-2"})  # Missing provider
+    assert not is_anthropic_claude(
+        {"provider": "other", "model": "claude-2"}
+    )  # Wrong provider
+
+
+def test_is_claude_37():
+    """Test is_claude_37 function with various model names."""
+    # Test positive cases
+    assert is_claude_37("claude-3.7")
+    assert is_claude_37("claude3.7")
+    assert is_claude_37("claude-3-7")
+    assert is_claude_37("anthropic/claude-3.7")
+    assert is_claude_37("anthropic/claude3.7")
+    assert is_claude_37("anthropic/claude-3-7")
+    assert is_claude_37("claude-3.7-sonnet")
+    assert is_claude_37("claude3.7-haiku")
+    
+    # Test negative cases
+    assert not is_claude_37("claude-3")
+    assert not is_claude_37("claude-3.5")
+    assert not is_claude_37("claude3.5")
+    assert not is_claude_37("claude-3-5")
+    assert not is_claude_37("gpt-4")
+    assert not is_claude_37("")


### PR DESCRIPTION

- We now adjust `max_input_tokens` for claude 3.7 specifically subtracting `max_tokens` as it has its own special API validation errors given context size: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#max-tokens-and-context-window-size-with-extended-thinking. 
- In llm.py there was a bug it sets `max_tokens` to 64000 by default breaking older claude 3.5 model token limits causing API errors. I've fixed this by adding in simple `max_tokens` params for model 3.7 only. 
  - Its interesting to note that sonnet 3.7 supports up to 128K but we are using 64K for now I think this is a good approach. If we did up the max_tokens, then our effective messages tokens list would need to be reduced as its running. 

feat(agent_utils.py): add model detection utilities for Claude 3.7 models
fix(agent_utils.py): update get_model_token_limit to handle Claude 3.7 token limits correctly
test(model_detection.py): add unit tests for model detection utilities
chore(agent_utils.py): remove deprecated is_anthropic_claude function and related tests
style(agent_utils.py): format code for better readability and consistency

Addresses: https://github.com/ai-christianson/RA.Aid/issues/115


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced support for specific language models with improved token limit adjustments.
  - Introduced advanced model detection to better handle various model types.

- **Refactor**
  - Streamlined configuration and import organization for improved clarity and maintainability.
  - Removed redundant functions to simplify internal workflows.

- **Tests**
  - Updated and added tests to validate the new token management and model detection features, ensuring consistent and reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->