### PR TITLE
Update shell.py for native windows support

### DIFF
--- a/ra_aid/tools/shell.py
+++ b/ra_aid/tools/shell.py
@@ -1,3 +1,5 @@
+import platform
+import shutil
 from typing import Dict, Union
 
 from langchain_core.tools import tool
@@ -15,6 +17,16 @@ from ra_aid.database.repositories.human_input_repository import get_human_input_
 
 console = Console()
 
+def _detect_shell():
+    """Detect the appropriate shell to use based on the environment."""
+    if platform.system().lower().startswith("win"):
+        # Check if pwsh is available, otherwise fall back to powershell
+        if shutil.which("pwsh"):
+            return ["pwsh", "-c"]
+        else:
+            return ["powershell", "-c"]
+    else:
+        return ["/bin/bash", "-c"]
 
 def _truncate_for_log(text: str, max_length: int = 300) -> str:
     """Truncate text for logging, adding [truncated] if necessary."""
@@ -98,8 +110,9 @@ def run_shell_command(
 
     try:
         print()
+        shell_cmd = _detect_shell()
         output, return_code = run_interactive_command(
-            ["/bin/bash", "-c", command],
+            shell_cmd + [command],
             expected_runtime_seconds=timeout,
         )
         print()


### PR DESCRIPTION
this change allows me to run ra-aid successfully in windows natively without the need of wsl 

thought it might be worth including in main to support more environments and solve /bin/bash errors when running on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic shell selection for command execution, ensuring optimal compatibility on both Windows and Unix-like systems.
  - Enhanced overall flexibility by automatically adapting the execution environment based on the detected operating system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->