### PR TITLE
fix(agent_utils.py): add check for model attribute to prevent errors …

### DIFF
--- a/ra_aid/agent_utils.py
+++ b/ra_aid/agent_utils.py
@@ -102,6 +102,9 @@ def build_agent_kwargs(
     ):
 
         def wrapped_state_modifier(state: AgentState) -> list[BaseMessage]:
+            if not hasattr(model, 'model'):
+                return state_modifier(state, model, max_input_tokens=max_input_tokens)
+
             if any(
                 pattern in model.model
                 for pattern in ["claude-3.5", "claude3.5", "claude-3-5"]


### PR DESCRIPTION
Really curious what the cli arguments were that produced this error, as initialize_llm BaseChatModels should have `model.model` set. Regardless this should fix error if its unset.