### PR TITLE
Use correct state_modifier when using openrouter claude 3.7

### DIFF
--- a/ra_aid/agent_utils.py
+++ b/ra_aid/agent_utils.py
@@ -52,6 +52,7 @@ from ra_aid.database.repositories.human_input_repository import (
 from ra_aid.database.repositories.trajectory_repository import get_trajectory_repository
 from ra_aid.database.repositories.config_repository import get_config_repository
 from ra_aid.anthropic_token_limiter import (
+    get_model_name_from_chat_model,
     sonnet_35_state_modifier,
     state_modifier,
     get_model_token_limit,
@@ -102,11 +103,10 @@ def build_agent_kwargs(
     ):
 
         def wrapped_state_modifier(state: AgentState) -> list[BaseMessage]:
-            if not hasattr(model, 'model'):
-                return state_modifier(state, model, max_input_tokens=max_input_tokens)
+            model_name = get_model_name_from_chat_model(model)
 
             if any(
-                pattern in model.model
+                pattern in model_name
                 for pattern in ["claude-3.5", "claude3.5", "claude-3-5"]
             ):
                 return sonnet_35_state_modifier(


### PR DESCRIPTION
…improve model handling

refactor(build_agent_kwargs): simplify state modifier logic by using model name instead of model attribute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the process for determining the agent model name, eliminating redundant checks and ensuring more consistent handling of model identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->