### PR TITLE
fix: wipe-project-memory returns an error code

### DIFF
--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -895,7 +895,7 @@ def main():
                     return
 
                 # Validate message is provided
-                if not args.message:
+                if not args.message and not args.wipe_project_memory:  # Add check for wipe_project_memory flag
                     try:
                         trajectory_repo = get_trajectory_repository()
                         human_input_id = get_human_input_repository().get_most_recent_id()
@@ -917,7 +917,8 @@ def main():
                     print_error("--message is required")
                     sys.exit(1)
 
-                base_task = args.message
+                if args.message:  # Only set base_task if message exists
+                    base_task = args.message
 
                 # Record CLI input in database
                 try:


### PR DESCRIPTION
Fixes #140 
before the `--wipe-project-memory`  required `--message` but now it is optional which solves the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Revised input validation to allow bypassing the required message when using the memory-wipe option, preventing unnecessary errors.
- **Refactor**
  - Streamlined task handling so that task details are only set when valid input is provided, ensuring smoother execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->