### PR TITLE
Fix type casting of LLM_REQUEST_TIMEOUT and LLM_MAX_RETRIES

### DIFF
--- a/ra_aid/llm.py
+++ b/ra_aid/llm.py
@@ -102,8 +102,8 @@ def create_deepseek_client(
                 0 if is_expert else (temperature if temperature is not None else 1)
             ),
             model=model_name,
-            timeout=get_env_var(name="LLM_REQUEST_TIMEOUT", default=LLM_REQUEST_TIMEOUT),
-            max_retries=get_env_var(name="LLM_MAX_RETRIES", default=LLM_MAX_RETRIES),
+            timeout=int(get_env_var(name="LLM_REQUEST_TIMEOUT", default=LLM_REQUEST_TIMEOUT)),
+            max_retries=int(get_env_var(name="LLM_MAX_RETRIES", default=LLM_MAX_RETRIES)),
         )
 
     return ChatOpenAI(
@@ -111,8 +111,8 @@ def create_deepseek_client(
         base_url=base_url,
         temperature=0 if is_expert else (temperature if temperature is not None else 1),
         model=model_name,
-        timeout=get_env_var(name="LLM_REQUEST_TIMEOUT", default=LLM_REQUEST_TIMEOUT),
-        max_retries=get_env_var(name="LLM_MAX_RETRIES", default=LLM_MAX_RETRIES),
+        timeout=int(get_env_var(name="LLM_REQUEST_TIMEOUT", default=LLM_REQUEST_TIMEOUT)),
+        max_retries=int(get_env_var(name="LLM_MAX_RETRIES", default=LLM_MAX_RETRIES)),
     )
 
 
@@ -133,8 +133,8 @@ def create_openrouter_client(
                 0 if is_expert else (temperature if temperature is not None else 1)
             ),
             model=model_name,
-            timeout=get_env_var(name="LLM_REQUEST_TIMEOUT", default=LLM_REQUEST_TIMEOUT),
-            max_retries=get_env_var(name="LLM_MAX_RETRIES", default=LLM_MAX_RETRIES),
+            timeout=int(get_env_var(name="LLM_REQUEST_TIMEOUT", default=LLM_REQUEST_TIMEOUT)),
+            max_retries=int(get_env_var(name="LLM_MAX_RETRIES", default=LLM_MAX_RETRIES)),
             default_headers=default_headers,
         )
 
@@ -142,8 +142,8 @@ def create_openrouter_client(
         api_key=api_key,
         base_url="https://openrouter.ai/api/v1",
         model=model_name,
-        timeout=get_env_var(name="LLM_REQUEST_TIMEOUT", default=LLM_REQUEST_TIMEOUT),
-        max_retries=get_env_var(name="LLM_MAX_RETRIES", default=LLM_MAX_RETRIES),
+        timeout=int(get_env_var(name="LLM_REQUEST_TIMEOUT", default=LLM_REQUEST_TIMEOUT)),
+        max_retries=int(get_env_var(name="LLM_MAX_RETRIES", default=LLM_MAX_RETRIES)),
         default_headers=default_headers,
         **({
             "temperature": temperature
@@ -338,16 +338,16 @@ def create_llm_client(
         return ChatOpenAI(
             **{
                 **openai_kwargs,
-                "timeout": get_env_var(name="LLM_REQUEST_TIMEOUT", default=LLM_REQUEST_TIMEOUT),
-                "max_retries": get_env_var(name="LLM_MAX_RETRIES", default=LLM_MAX_RETRIES),
+                "timeout": int(get_env_var(name="LLM_REQUEST_TIMEOUT", default=LLM_REQUEST_TIMEOUT)),
+                "max_retries": int(get_env_var(name="LLM_MAX_RETRIES", default=LLM_MAX_RETRIES)),
             }
         )
     elif provider == "anthropic":
         return ChatAnthropic(
             api_key=config.get("api_key"),
             model_name=model_name,
-            timeout=get_env_var(name="LLM_REQUEST_TIMEOUT", default=LLM_REQUEST_TIMEOUT),
-            max_retries=get_env_var(name="LLM_MAX_RETRIES", default=LLM_MAX_RETRIES),
+            timeout=int(get_env_var(name="LLM_REQUEST_TIMEOUT", default=LLM_REQUEST_TIMEOUT)),
+            max_retries=int(get_env_var(name="LLM_MAX_RETRIES", default=LLM_MAX_RETRIES)),
             **temp_kwargs,
             **thinking_kwargs,
             **other_kwargs,
@@ -357,8 +357,8 @@ def create_llm_client(
             api_key=config.get("api_key"),
             base_url=config.get("base_url"),
             model=model_name,
-            timeout=get_env_var(name="LLM_REQUEST_TIMEOUT", default=LLM_REQUEST_TIMEOUT),
-            max_retries=get_env_var(name="LLM_MAX_RETRIES", default=LLM_MAX_RETRIES),
+            timeout=int(get_env_var(name="LLM_REQUEST_TIMEOUT", default=LLM_REQUEST_TIMEOUT)),
+            max_retries=int(get_env_var(name="LLM_MAX_RETRIES", default=LLM_MAX_RETRIES)),
             **temp_kwargs,
             **thinking_kwargs,
         )
@@ -366,8 +366,8 @@ def create_llm_client(
         return ChatGoogleGenerativeAI(
             api_key=config.get("api_key"),
             model=model_name,
-            timeout=get_env_var(name="LLM_REQUEST_TIMEOUT", default=LLM_REQUEST_TIMEOUT),
-            max_retries=get_env_var(name="LLM_MAX_RETRIES", default=LLM_MAX_RETRIES),
+            timeout=int(get_env_var(name="LLM_REQUEST_TIMEOUT", default=LLM_REQUEST_TIMEOUT)),
+            max_retries=int(get_env_var(name="LLM_MAX_RETRIES", default=LLM_MAX_RETRIES)),
             **temp_kwargs,
             **thinking_kwargs,
         )


### PR DESCRIPTION
This is a fix for https://github.com/ai-christianson/RA.Aid/pull/148

Added casting to int for env vars LLM_REQUEST_TIMEOUT and LLM_MAX_RETRIES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the handling of configuration settings for connection timeouts and retry attempts. This update ensures that these parameters are consistently interpreted, enhancing overall system reliability and the smooth operation of client interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->