### PR TITLE
Removing aider-chat as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ You can get your API keys from:
 - OpenRouter API key: https://openrouter.ai/keys
 - Gemini API key: https://aistudio.google.com/app/apikey
 
+Note: `aider` must be installed separately as it is not included in the RA.Aid package. See [aider-chat](https://pypi.org/project/aider-chat/) for more details.
+
 Complete installation documentation is available in our [Installation Guide](https://docs.ra-aid.ai/quickstart/installation).
 
 ## Usage

--- a/docs/docs/quickstart/recommended.md
+++ b/docs/docs/quickstart/recommended.md
@@ -61,6 +61,8 @@ If you prefer to use aider's specialized code editing capabilities instead of RA
 ra-aid -m "Implement this feature" --use-aider
 ```
 
+Note: aider must be installed separately. See [aider-chat](https://pypi.org/project/aider-chat/) for more information.
+
 You can control logging verbosity and location using the `--log-mode` and `--log-level` options:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "rapidfuzz>=3.11.0",
     "pathspec>=0.11.0",
     "pyte>=0.8.2",
-    "aider-chat>=0.75.1",
     "tavily-python>=0.5.0",
     "litellm>=1.60.6",
     "fastapi>=0.104.0",


### PR DESCRIPTION
Removing `aider-chat` as a dependency; updated README and docs accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation notes in the README and quickstart guides to clarify that the aider tool needs to be installed separately, with a link provided for more information.
  
- **Chores**
  - Removed the aider-chat dependency from the project's configuration, streamlining the dependency setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->