### PR TITLE
Added `--msg-file` argument support

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ More information is available in our [Usage Examples](https://docs.ra-aid.ai/cat
 
 ### Command Line Options
 
-- `-m, --message`: The task or query to be executed (required except in chat mode)
+- `-m, --message`: The task or query to be executed (required except in chat mode, cannot be used with --msg-file)
+- `--msg-file`: Path to a text file containing the task/message (cannot be used with --message)
 - `--research-only`: Only perform research without implementation
 - `--provider`: The LLM provider to use (choices: anthropic, openai, openrouter, openai-compatible, gemini)
 - `--model`: The model name to use (required for non-Anthropic providers)

--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -267,7 +267,6 @@ Examples:
     ra-aid -m "Add error handling to the database module"
     ra-aid -m "Explain the authentication flow" --research-only
     ra-aid --msg-file task_description.txt
-    ra-aid --msg-file task_description.txt
         """,
     )
     parser.add_argument(

--- a/tests/ra_aid/test_main.py
+++ b/tests/ra_aid/test_main.py
@@ -329,6 +329,27 @@ def test_missing_message():
     assert args.message == "test"
 
 
+def test_msg_file_argument(tmp_path):
+    """Test --msg-file argument handling."""
+    # Create a test file
+    test_file = tmp_path / "test_task.txt"
+    test_file.write_text("Test task content")
+
+    # Test reading from file
+    args = parse_arguments(["--msg-file", str(test_file)])
+    assert args.message == "Test task content"
+    assert args.msg_file == str(test_file)
+
+    # Test mutual exclusivity with --message
+    with pytest.raises(SystemExit):
+        parse_arguments(["--msg-file", str(test_file), "-m", "direct message"])
+
+    # Test non-existent file
+    non_existent = tmp_path / "nonexistent.txt"
+    with pytest.raises(SystemExit):
+        parse_arguments(["--msg-file", str(non_existent)])
+
+
 def test_research_model_provider_args(mock_dependencies, mock_config_repository):
     """Test that research-specific model/provider args are correctly stored in config."""
     import sys


### PR DESCRIPTION
## Description
This PR adds a new `--msg-file` argument to allow loading task messages from files, improving usability for complex/long tasks.

## Changes
- Added new `--msg-file` argument that accepts a file path
- Implemented file reading logic that loads contents into `args.message`
- Added validation to ensure mutual exclusivity with `--message`
- Added file existence checking with clear error messages
- Added comprehensive tests covering:
  - File reading functionality
  - Mutual exclusivity validation
  - Error handling for missing files
- Updated documentation in both README and CLI help text

## Usage Examples
```bash
# Basic usage
ra-aid --msg-file task_description.txt

# With other arguments
ra-aid --msg-file complex_task.md --research-only --provider anthropic
```

## Benefits
- Allows storing complex/long tasks in files rather than command line
- Supports markdown/plain text files for better formatting
- Maintains all existing functionality while adding new option



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated usage instructions to clarify the newly added file-based message option and its mutual exclusivity with direct message input.

- **New Features**
  - Introduced a command line option that allows users to provide task messages via a text file.
  - Enhanced error handling to prevent the use of both file-based and direct message options simultaneously.

- **Tests**
  - Added tests to validate correct file content handling and error reporting for the new file-based message support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->