### PR TITLE
Fix SyntaxError: f-string: expecting '}'

### DIFF
--- a/ra_aid/agent_backends/ciayn_agent.py
+++ b/ra_aid/agent_backends/ciayn_agent.py
@@ -723,7 +723,7 @@ class CiaynAgent:
                 )
 
             ra_aid.console.formatting.print_warning(
-                f"Tool execution failed for `{tool_name if tool_name else "unknown"}`:\nError: {str(e)}\n\nCode:\n\n````\n{code}\n````",
+                f"Tool execution failed for `{tool_name if tool_name else 'unknown'}`:\nError: {str(e)}\n\nCode:\n\n````\n{code}\n````",
                 title="Tool Error",
             )
             # Re-raise the original error if it's already a ToolExecutionError and we didn't modify it


### PR DESCRIPTION
Replace nested double quotes with single quotes to resolve SyntaxError: f-string: expecting '}'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the formatting of error messages for improved consistency; end-user functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->