### PR TITLE
only call fix triple quotes when necessary

### DIFF
--- a/ra_aid/agent_backends/ciayn_agent.py
+++ b/ra_aid/agent_backends/ciayn_agent.py
@@ -341,7 +341,22 @@ class CiaynAgent:
 
         try:
             code = self.strip_code_markup(code)
-            code = fix_triple_quote_contents(code)
+            
+            # Only call fix_triple_quote_contents if:
+            # 1. The code is not valid Python AND
+            # 2. The first line includes "put_complete_file_contents"
+            is_valid_python = True
+            try:
+                ast.parse(code)
+            except SyntaxError:
+                is_valid_python = False
+            
+            # Check if first line includes "put_complete_file_contents"
+            first_line = code.splitlines()[0] if code.splitlines() else ""
+            contains_put_complete = "put_complete_file_contents" in first_line
+            
+            if not is_valid_python and contains_put_complete:
+                code = fix_triple_quote_contents(code)
 
             # Check for multiple tool calls that can be bundled
             tool_calls = self._detect_multiple_tool_calls(code)


### PR DESCRIPTION
## Summary

This change modifies the `_parse_tool_call` method in `ra_aid/agent_backends/ciayn_agent.py`. The `fix_triple_quote_contents` function, which aims to correct improperly escaped triple quotes in code blocks generated by the LLM, is now applied conditionally instead of unconditionally.

## Conditional Logic

`fix_triple_quote_contents` is now invoked **only if both** of the following conditions are met:

1.  The code block extracted from the LLM response fails Python's `ast.parse`, indicating a potential syntax error (often due to incorrect triple-quote escaping).
2.  The first line of the code block contains the string `"put_complete_file_contents"`.

## Rationale

This change makes the triple-quote fixing logic more targeted. It focuses the fix specifically on the `put_complete_file_contents` tool calls where these quoting issues are most likely to cause problems, and only attempts the fix when the code is already detected as syntactically invalid Python. This avoids potential unintended modifications to valid code or code generated for other tools.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the system’s error handling and input processing to apply corrective actions only when necessary, improving overall stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->