### PR TITLE
Support gemini-2.5-pro-preview-03-25 and auto select gemini model as default

### DIFF
--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -526,7 +526,7 @@ Examples:
         # Use default model for Anthropic only if not specified
         parsed_args.model = parsed_args.model or ANTHROPIC_DEFAULT_MODEL
     elif parsed_args.provider == "gemini":
-        parsed_args.model = parsed_args.model or "gemini-2.5-pro-exp-03-25"
+        parsed_args.model = parsed_args.model or "gemini-2.5-pro-preview-03-25"
     elif not parsed_args.model and not parsed_args.research_only:
         # Require model for other providers unless in research mode
         parser.error(
@@ -538,7 +538,7 @@ Examples:
         # Check for Gemini API key first
         if os.environ.get("GEMINI_API_KEY"):
             parsed_args.expert_provider = "gemini"
-            parsed_args.expert_model = "gemini-2.5-pro-exp-03-25"
+            parsed_args.expert_model = "gemini-2.5-pro-preview-03-25"
         # Check for OpenAI API key next
         elif os.environ.get("OPENAI_API_KEY"):
             parsed_args.expert_provider = "openai"

--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -295,9 +295,13 @@ Examples:
         "--provider",
         type=str,
         default=(
-            "openai"
-            if (os.getenv("OPENAI_API_KEY") and not os.getenv("ANTHROPIC_API_KEY"))
-            else "anthropic"
+            "gemini"
+            if os.getenv("GEMINI_API_KEY")
+            else (
+                "openai"
+                if (os.getenv("OPENAI_API_KEY") and not os.getenv("ANTHROPIC_API_KEY"))
+                else "anthropic"
+            )
         ),
         choices=VALID_PROVIDERS,
         help="The LLM provider to use",
@@ -521,6 +525,8 @@ Examples:
     elif parsed_args.provider == "anthropic":
         # Use default model for Anthropic only if not specified
         parsed_args.model = parsed_args.model or ANTHROPIC_DEFAULT_MODEL
+    elif parsed_args.provider == "gemini":
+        parsed_args.model = parsed_args.model or "gemini-2.5-pro-exp-03-25"
     elif not parsed_args.model and not parsed_args.research_only:
         # Require model for other providers unless in research mode
         parser.error(
@@ -529,8 +535,12 @@ Examples:
 
     # Handle expert provider/model defaults
     if not parsed_args.expert_provider:
-        # Check for OpenAI API key first
-        if os.environ.get("OPENAI_API_KEY"):
+        # Check for Gemini API key first
+        if os.environ.get("GEMINI_API_KEY"):
+            parsed_args.expert_provider = "gemini"
+            parsed_args.expert_model = "gemini-2.5-pro-exp-03-25"
+        # Check for OpenAI API key next
+        elif os.environ.get("OPENAI_API_KEY"):
             parsed_args.expert_provider = "openai"
             parsed_args.expert_model = None  # Will be auto-selected
         # If no OpenAI key but DeepSeek key exists, use DeepSeek

--- a/ra_aid/models_params.py
+++ b/ra_aid/models_params.py
@@ -454,6 +454,14 @@ models_params = {
             "latency_coefficient": DEFAULT_BASE_LATENCY,
             "default_backend": AgentBackendType.CIAYN,
         },
+        "gemini-2.5-pro-preview-03-25": {
+            "token_limit": 1048576,
+            "max_tokens": 1048576,
+            "supports_temperature": True,
+            "default_temperature": 1.0,
+            "latency_coefficient": DEFAULT_BASE_LATENCY,
+            "default_backend": AgentBackendType.CIAYN,
+        },
     },
     "ollama": {
         "command-r": {


### PR DESCRIPTION
## Description

This pull request introduces support for Google's Gemini models within the RA-AID framework.

**Key Changes:**

1.  **Default Provider Prioritization:**
    *   The default LLM provider logic in `ra_aid/__main__.py` has been updated.
    *   If the `GEMINI_API_KEY` environment variable is detected, "gemini" is now selected as the default provider.
    *   The previous default logic (checking `OPENAI_API_KEY` then `ANTHROPIC_API_KEY`) serves as a fallback.

2.  **Default Model for Gemini:**
    *   When "gemini" is the selected provider, the default model is automatically set to `gemini-2.5-pro-preview-03-25`.

3.  **Expert Provider Prioritization:**
    *   Similar to the default provider, the expert provider logic now checks for `GEMINI_API_KEY` first.
    *   If found, the expert provider is set to "gemini" and the expert model to `gemini-2.5-pro-preview-03-25`.
    *   The previous expert logic (checking OpenAI, then DeepSeek/Anthropic) acts as a fallback.

4.  **Model Parameters:**
    *   The `gemini-2.5-pro-preview-03-25` model has been added to `ra_aid/models_params.py` with its corresponding token limits and other parameters.

**Impact:**

This change makes Gemini the preferred provider for users who have configured a `GEMINI_API_KEY`, potentially leveraging newer and more capable models by default. Existing setups relying on OpenAI or Anthropic keys will remain unaffected.
