### PR TITLE
feat: add cowboy mode to --server mode with explicit user confirm

### DIFF
--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -12,6 +12,7 @@ from langgraph.checkpoint.memory import MemorySaver
 from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
+from rich.prompt import Confirm
 
 from ra_aid import print_error, print_stage_header
 from ra_aid.__version__ import __version__
@@ -240,6 +241,7 @@ def launch_server(host: str, port: int, args):
                 "show_cost": args.show_cost,
                 "force_reasoning_assistance": args.reasoning_assistance,
                 "disable_reasoning_assistance": args.no_reasoning_assistance,
+                "cowboy_mode": args.cowboy_mode,
             }
         )
 
@@ -747,6 +749,14 @@ def main():
 
     # Launch web interface if requested
     if args.server:
+        if args.cowboy_mode:
+            if not Confirm.ask(
+                "WARNING: Running in server mode with cowboy mode enabled allows the Web UI " \
+                "to execute shell commands without confirmation. Continue?", default=False
+            ):
+                print("Exiting due to user cancellation.")
+                sys.exit(0)
+
         launch_server(args.server_host, args.server_port, args)
         return
 
@@ -863,6 +873,7 @@ def main():
                 config_repo.set(
                     "custom_tools_enabled", True if args.custom_tools else False
                 )
+                config_repo.set("cowboy_mode", args.cowboy_mode) # Also add here for non-server mode
 
                 # Validate custom tools function signatures
                 get_custom_tools()
@@ -989,6 +1000,7 @@ def main():
                     config_repo.set(
                         "disable_reasoning_assistance", args.no_reasoning_assistance
                     )
+                    config_repo.set("cowboy_mode", args.cowboy_mode) # Chat mode also needs cowboy mode
 
                     # Set modification tools based on use_aider flag
                     set_modification_tools(args.use_aider)
@@ -1126,6 +1138,8 @@ def main():
                 config_repo.set(
                     "disable_reasoning_assistance", args.no_reasoning_assistance
                 )
+                # Store cowboy_mode for the main agent run
+                config_repo.set("cowboy_mode", args.cowboy_mode)
 
                 # Set modification tools based on use_aider flag
                 set_modification_tools(args.use_aider)


### PR DESCRIPTION
From plan summary:

> When starting the server with both --server and --cowboy-mode, you will now be asked for confirmation before the server starts, warning you about unattended command execution.

> If you confirm, the cowboy_mode setting will be correctly stored and passed to any agent sessions created through the Web UI, allowing shell commands to run without further prompts in those sessions.    

> The relevant changes were made in ra_aid/__main__.py.

Screenshot:

![image](https://github.com/user-attachments/assets/6b8cb147-8990-4d2a-be33-f1c1bef07dca)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `--cowboy-mode` command-line option to allow skipping interactive approval prompts for shell commands.
  - Added a security warning prompt when enabling cowboy mode in server mode, requiring user confirmation before proceeding.
- **Chores**
  - Ensured cowboy mode setting is consistently stored and available across all application modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->