### PR TITLE
Support `o3` and `o4-mini` variant models

### DIFF
--- a/ra_aid/llm.py
+++ b/ra_aid/llm.py
@@ -516,8 +516,13 @@ def create_llm_client(
             "model": model_name,
             **temp_kwargs,
         }
-        if is_expert and model_config.get("supports_reasoning_effort", False):
-            openai_kwargs["reasoning_effort"] = "high"
+        if is_expert:
+            if model_config.get("supports_reasoning_effort", False):
+                # If the model supports reasoning effort, we set it to high as default
+                openai_kwargs["reasoning_effort"] = "high"
+            if not model_config.get("supports_temperature", False):
+                # If the model doesn't support temperature, we remove it from the kwargs
+                openai_kwargs.pop("temperature", None)
 
         return ChatOpenAI(
             **{

--- a/ra_aid/models_params.py
+++ b/ra_aid/models_params.py
@@ -100,6 +100,14 @@ models_params = {
             "latency_coefficient": DEFAULT_BASE_LATENCY,
             "default_backend": AgentBackendType.CREATE_REACT_AGENT,
         },
+        "o4-mini-2025-04-16": {
+            "token_limit": 200000,
+            "supports_temperature": False,
+            "default_temperature": 1.0,
+            "supports_reasoning_effort": True,
+            "latency_coefficient": DEFAULT_BASE_LATENCY,
+            "default_backend": AgentBackendType.CREATE_REACT_AGENT,
+        },
         "o3": {
             "token_limit": 200000,
             "supports_temperature": False,

--- a/ra_aid/models_params.py
+++ b/ra_aid/models_params.py
@@ -95,7 +95,6 @@ models_params = {
         "o4-mini": {
             "token_limit": 200000,
             "supports_temperature": False,
-            "default_temperature": 1.0,
             "supports_reasoning_effort": True,
             "latency_coefficient": DEFAULT_BASE_LATENCY,
             "default_backend": AgentBackendType.CREATE_REACT_AGENT,
@@ -103,7 +102,6 @@ models_params = {
         "o4-mini-2025-04-16": {
             "token_limit": 200000,
             "supports_temperature": False,
-            "default_temperature": 1.0,
             "supports_reasoning_effort": True,
             "latency_coefficient": DEFAULT_BASE_LATENCY,
             "default_backend": AgentBackendType.CREATE_REACT_AGENT,
@@ -111,7 +109,6 @@ models_params = {
         "o3": {
             "token_limit": 200000,
             "supports_temperature": False,
-            "default_temperature": 1.0,
             "supports_reasoning_effort": True,
             "latency_coefficient": DEFAULT_BASE_LATENCY,
             "default_backend": AgentBackendType.CIAYN,
@@ -119,7 +116,6 @@ models_params = {
         "o3-2025-04-16": {
             "token_limit": 200000,
             "supports_temperature": False,
-            "default_temperature": 1.0,
             "supports_reasoning_effort": True,
             "latency_coefficient": DEFAULT_BASE_LATENCY,
             "default_backend": AgentBackendType.CIAYN,

--- a/ra_aid/models_params.py
+++ b/ra_aid/models_params.py
@@ -116,6 +116,14 @@ models_params = {
             "latency_coefficient": DEFAULT_BASE_LATENCY,
             "default_backend": AgentBackendType.CIAYN,
         },
+        "o3-2025-04-16": {
+            "token_limit": 200000,
+            "supports_temperature": False,
+            "default_temperature": 1.0,
+            "supports_reasoning_effort": True,
+            "latency_coefficient": DEFAULT_BASE_LATENCY,
+            "default_backend": AgentBackendType.CIAYN,
+        },
         "gpt-4.1": {
             "token_limit": 1000000,
             "supports_temperature": True,

--- a/ra_aid/models_params.py
+++ b/ra_aid/models_params.py
@@ -288,6 +288,12 @@ models_params = {
             "supports_reasoning_effort": True,
             "latency_coefficient": DEFAULT_BASE_LATENCY,
         },
+        "o3-mini-2025-01-31": {
+            "token_limit": 200000,
+            "supports_temperature": False,
+            "supports_reasoning_effort": True,
+            "latency_coefficient": DEFAULT_BASE_LATENCY,
+        },
     },
     "openrouter": {
         "qwen/qwen-2.5-coder-32b-instruct": {


### PR DESCRIPTION
### **PR Type**
Enhancement

___

### **PR Description**
- Added support for `o3`, `o3-mini`, and `o4-mini` variant models.
  - Includes dated variants like `o3-2025-04-16` and `o3-mini-2025-01-31`.
  - Includes `o4-mini-2025-04-16`.

- Updated model configuration to remove `default_temperature` for models that do not support temperature.

- Modified logic to exclude `temperature` parameter for models that do not support it.

- Ensured `reasoning_effort` is set to `high` for expert mode when supported.
