### PR TITLE
bugfix: configure websocket connection to match window.host

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -72,6 +72,17 @@ pip install -e .
 ra-aid -m "Your task or query here"
 ```
 
+5. Frontend miscellany:
+
+```bash
+# run development server on port 5173
+cd frontend/
+yarn dev
+
+# run development server on other ports
+VITE_PORT=5555 VITE_BACKEND_PORT=7777 yarn dev
+```
+
 ## This is Your Project Too
 
 RA.Aid is a community project that grows stronger with each contribution. Whether it's fixing a typo in documentation, reporting a bug, or adding a new feature - every contribution matters and is valued.

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -74,13 +74,19 @@ ra-aid -m "Your task or query here"
 
 5. Frontend miscellany:
 
+The backend must always be run using `ra-aid --server` separately. `yarn dev` is used to run the frontend development server.
+
 ```bash
 # run development server on port 5173
 cd frontend/
 yarn dev
 
-# run development server on other ports
-VITE_PORT=5555 VITE_BACKEND_PORT=7777 yarn dev
+# run development bundle for other ports
+# (the prebuilt bundle from uvicorn always serves both frontend and backend on --server-port argument)
+VITE_FRONTEND_PORT=5555 yarn dev  # hosts web app on 5555 targeting backend on 1818
+VITE_FRONTEND_PORT=2221 VITE_BACKEND_PORT=9191 yarn dev  # hosts web app on 2221 targeting backend on 9191
+VITE_BACKEND_PORT=4002 yarn dev  # hosts web app on 5173 (vite default port) targeting backend on 4002
+yarn dev  # hosts web app on 5173 (default) targeting backend on 1818
 ```
 
 ## This is Your Project Too

--- a/frontend/common/src/store/clientConfigStore.ts
+++ b/frontend/common/src/store/clientConfigStore.ts
@@ -70,8 +70,8 @@ type ClientConfigStore = ClientConfigState & ClientConfigActions;
  * Default configuration values
  */
 const DEFAULT_CONFIG = ClientConfigSchema.parse({
-  host: 'localhost',
-  port: 1818
+  host: window?.location?.hostname || 'localhost',
+  port: Number.parseInt(window?.location?.port) || 1818
 });
 
 /**

--- a/frontend/common/src/store/clientConfigStore.ts
+++ b/frontend/common/src/store/clientConfigStore.ts
@@ -73,15 +73,14 @@ type ClientConfigStore = ClientConfigState & ClientConfigActions;
  * The default client configuration object, parsed using the `ClientConfigSchema`.
  * 
  * - `host`: Defaults to the current window's hostname, or 'localhost' if unavailable.
- * - `port`: Determines the port based on the current window's location port:
- *   - If the port is `5173` (used by Vite's development HMR server), it defaults to `1818` 
- *     to connect to the default Python backend.
- *   - Otherwise, it uses the current window's location port or falls back to `1818`.
+ * - `port`: Determines the port based on the environment:
+ *   - In `vite dev` server, it uses the `VITE_BACKEND_PORT` environment variable, defaulting to `1818` if not set.
+ *   - In `vite build` (prebuilt production), it uses the current `window.location.port`, defaulting to `1818` if unavailable.
  */
-const BACKEND_PORT = import.meta.env.VITE_BACKEND_PORT ? Number.parseInt(import.meta.env.VITE_BACKEND_PORT) : 1818;
+const backend_port = import.meta.env.DEV ? Number.parseInt(import.meta.env.VITE_BACKEND_PORT || '1818') : Number.parseInt(window?.location?.port || '1818');
 const DEFAULT_CONFIG = ClientConfigSchema.parse({
   host: window?.location?.hostname || 'localhost',
-  port: Number.parseInt(window?.location?.port === '5173' ? `${BACKEND_PORT}` : window?.location?.port) || BACKEND_PORT
+  port: backend_port
 });
 
 /**

--- a/frontend/common/src/store/clientConfigStore.ts
+++ b/frontend/common/src/store/clientConfigStore.ts
@@ -69,9 +69,18 @@ type ClientConfigStore = ClientConfigState & ClientConfigActions;
 /**
  * Default configuration values
  */
+/**
+ * The default client configuration object, parsed using the `ClientConfigSchema`.
+ * 
+ * - `host`: Defaults to the current window's hostname, or 'localhost' if unavailable.
+ * - `port`: Determines the port based on the current window's location port:
+ *   - If the port is `5173` (used by Vite's development HMR server), it defaults to `1818` 
+ *     to connect to the default Python backend.
+ *   - Otherwise, it uses the current window's location port or falls back to `1818`.
+ */
 const DEFAULT_CONFIG = ClientConfigSchema.parse({
   host: window?.location?.hostname || 'localhost',
-  port: Number.parseInt(window?.location?.port) || 1818
+  port: Number.parseInt(window?.location?.port === '5173' ? '1818' : window?.location?.port) || 1818
 });
 
 /**

--- a/frontend/common/src/store/clientConfigStore.ts
+++ b/frontend/common/src/store/clientConfigStore.ts
@@ -78,9 +78,10 @@ type ClientConfigStore = ClientConfigState & ClientConfigActions;
  *     to connect to the default Python backend.
  *   - Otherwise, it uses the current window's location port or falls back to `1818`.
  */
+const BACKEND_PORT = import.meta.env.VITE_BACKEND_PORT ? Number.parseInt(import.meta.env.VITE_BACKEND_PORT) : 1818;
 const DEFAULT_CONFIG = ClientConfigSchema.parse({
   host: window?.location?.hostname || 'localhost',
-  port: Number.parseInt(window?.location?.port === '5173' ? '1818' : window?.location?.port) || 1818
+  port: Number.parseInt(window?.location?.port === '5173' ? `${BACKEND_PORT}` : window?.location?.port) || BACKEND_PORT
 });
 
 /**

--- a/frontend/web/vite.config.js
+++ b/frontend/web/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import fs from 'fs';
@@ -6,35 +6,40 @@ import fs from 'fs';
 // Get all component files from common package
 const commonSrcDir = path.resolve(__dirname, '../common/src');
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      // Direct alias to the source directory
-      '@ra-aid/common': path.resolve(__dirname, '../common/src')
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd());
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        // Direct alias to the source directory
+        '@ra-aid/common': path.resolve(__dirname, '../common/src')
+      },
+      preserveSymlinks: true
     },
-    preserveSymlinks: true
-  },
-  optimizeDeps: {
-    // Exclude the common package from optimization so it can trigger hot reload
-    exclude: ['@ra-aid/common']
-  },
-  server: {
-    hmr: true,
-    watch: {
-      usePolling: true,
-      interval: 100,
-      // Make sure to explicitly NOT ignore the common package
-      ignored: [
-        '**/node_modules/**',
-        '**/dist/**',
-        '!**/common/src/**'
-      ]
-    }
-  },
-  build: {
-    commonjsOptions: {
-      transformMixedEsModules: true
+    optimizeDeps: {
+      // Exclude the common package from optimization so it can trigger hot reload
+      exclude: ['@ra-aid/common']
+    },
+    server: {
+      port: parseInt(env.VITE_FRONTEND_PORT || '5173'),
+      hmr: true,
+      watch: {
+        usePolling: true,
+        interval: 100,
+        // Make sure to explicitly NOT ignore the common package
+        ignored: [
+          '**/node_modules/**',
+          '**/dist/**',
+          '!**/common/src/**'
+        ]
+      }
+    },
+    build: {
+      commonjsOptions: {
+        transformMixedEsModules: true
+      }
     }
   }
 });


### PR DESCRIPTION
The frontend/ websocket connection string was hard-coded to `'localhost'`. This updates to use `window?.location?.hostname` and `port` so it will match whatever you are serving the backend uvicorn server `index.html` (and therefore the `/v1/ws` routes).

The backend uvicorn server already binds to `0.0.0.0:1818` by default but the client-side code was hard-coded to `'localhost'` so I couldn't run the app over VPN/LAN/my phone.

---

further edits -- adds support for `VITE_BACKEND_PORT` and `VITE_FRONTEND_PORT` for vite development server

1. Updates websocket connection string hostname to use `window.location.host`
2. `yarn dev` uses websocket port env:`VITE_BACKEND_PORT` or `1818` if unset
3. `yarn build # prebuilt` uses websocket port `window.location.port`
4. `yarn dev` now supports env:`VITE_FRONTEND_PORT` to override default port 5173

so for prebuilt server with frontend/backend on same port:

`cd project_a; ra-aid --server --server-port 1111` serves frontend and backend on `1111`

or for backend + hot-reload dev server:

`cd project_b; ra-aid --server --server-port 2221` serves backend on `2221`
`cd ra-aid/frontend/web; VITE_BACKEND_PORT=2221 VITE_FRONTEND_PORT=2222` serves SPA on `2222` pointing at backend on `221

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated default client configuration to automatically use the current browser's host and port, improving adaptability to different runtime environments.
  - Enhanced frontend development server setup to support dynamic port configuration via environment variables.
- **Documentation**
  - Added detailed instructions for running frontend and backend servers with customizable ports in the contributing guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->