### PR TITLE
feat(ciayn_agent): add wrapper for custom tool call results validation

### DIFF
--- a/ra_aid/agent_backends/ciayn_agent.py
+++ b/ra_aid/agent_backends/ciayn_agent.py
@@ -88,6 +88,12 @@ def validate_function_call_pattern(s: str) -> bool:
         return True
 
 
+def wrap_custom_tool_call_result(result) -> BaseMessage:
+    if isinstance(result, BaseMessage):
+        return result
+    return AIMessage(content=str(result))
+
+
 class CiaynAgent:
     """Code Is All You Need (CIAYN) agent that uses generated Python code for tool interaction.
 
@@ -682,8 +688,8 @@ class CiaynAgent:
 
             # Only display console output for custom tools
             if is_custom_tool:
-                custom_tool_output = f"Executing custom tool: {tool_name}\\n"
-                custom_tool_output += f"\\n\tResult: {result}"
+                custom_tool_output = f"Executing custom tool: {tool_name}\n"
+                custom_tool_output += f"\n\tResult: {result}"
                 ra_aid.console.formatting.console.print(
                     ra_aid.console.formatting.Panel(
                         ra_aid.console.formatting.Markdown(custom_tool_output.strip()),
@@ -691,7 +697,8 @@ class CiaynAgent:
                         border_style="magenta",
                     )
                 )
-
+                # Coerce custom tool call responses to langchain BaseMessage
+                result = wrap_custom_tool_call_result(result)
             return result
         except Exception as e:
             error_msg = f"Error: {str(e)} \\n Could not execute code: {code}"


### PR DESCRIPTION
User on discord pointed out that [context7](https://context7.com/about) MCP server was not working. I troubleshooted briefly and it seemed to be returning a tuple instead of a response of type `langchain` `BaseMessage`.

This code adds a fallback to serialize any custom tool response to `BaseMessage` using whatever return object's `__str__` method.

`ra-aid` is using [langchain-ai/langchain-mcp-adapters](https://github.com/langchain-ai/langchain-mcp-adapters) library which should return langchain messages.

I did test with context7 and it was able to tool call the MCP server and retrieve tailwindcss documentation (tailwind was the library i tried).

prompt tested:

```
do not use web research. you must use context7 to fetch documentation. fetch documentation for tailwindcss and update index.css to add a purple-colored theme variant. use context7 tokens size of 50000.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency in tool call results to ensure all outputs are properly formatted and displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->