### PR TITLE
MCP-USE integration with inclusion of context7 mcp server integration

### DIFF
--- a/examples/context7.json
+++ b/examples/context7.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "langchain-mcp-adapters>=0.0.5",
     "langchain-deepseek>=0.1.2",
     "langchain-text-splitters>=0.3.7",
+    "mcp-use>=1.2.7",
 ]
 
 [project.optional-dependencies]

--- a/ra_aid/__main__.py
+++ b/ra_aid/__main__.py
@@ -83,6 +83,8 @@ from ra_aid.server.server import app as fastapi_app
 from ra_aid.tool_configs import get_chat_tools, set_modification_tools, get_custom_tools
 from ra_aid.tools.human import ask_human
 
+import atexit
+
 logger = get_logger(__name__)
 
 # Configure litellm to suppress debug logs
@@ -270,6 +272,9 @@ Examples:
     ra-aid -m "Add error handling to the database module"
     ra-aid -m "Explain the authentication flow" --research-only
     ra-aid --msg-file task_description.txt
+    ra-aid -m "Use context7 to find latest pandas API for reading CSVs" # Context7 enabled by default
+    ra-aid -m "Implement feature X" --no-context7 # Disable default Context7
+    ra-aid -m "Use my custom browser tool" --mcp-use-config ./my_browser_mcp.json --no-context7 # Use specific MCP config
         """,
     )
     parser.add_argument(
@@ -343,6 +348,7 @@ Examples:
         default=None,
         choices=VALID_PROVIDERS,
         help="The LLM provider to use for expert knowledge queries",
+
     )
     parser.add_argument(
         "--expert-model",
@@ -496,6 +502,17 @@ Examples:
         type=str,
         help="File path of Python module containing custom tools (e.g. ./path/to_custom_tools.py)",
     )
+    parser.add_argument(
+        "--mcp-use-config",
+        type=str,
+        help="Path to MCP-Use JSON config file (enables MCP-Use tools)",
+    )
+    parser.add_argument(
+        "--no-context7",
+        action="store_true",
+        help="Disable the default Context7 MCP server integration",
+    )
+
     if args is None:
         args = sys.argv[1:]
     parsed_args = parser.parse_args(args)
@@ -889,10 +906,54 @@ def main():
                 config_repo.set(
                     "custom_tools_enabled", True if args.custom_tools else False
                 )
+                # Handle MCP-Use config
+                mcp_use_config_path = args.mcp_use_config
+                load_default_context7 = not args.no_context7
+
+                if mcp_use_config_path and load_default_context7:
+                    logger.warning(
+                        "--mcp-use-config is provided, ignoring default Context7 integration. "
+                        "Use --no-context7 if you only want the specified config."
+                    )
+                    load_default_context7 = False # Explicit config takes precedence
+
+                if load_default_context7:
+                    # Construct the path relative to the script's location
+                    script_dir = os.path.dirname(os.path.abspath(__file__))
+                    default_context7_path = os.path.join(script_dir, "..", "examples", "context7.json")
+                    if os.path.exists(default_context7_path):
+                        mcp_use_config_path = default_context7_path
+                        logger.info(f"Using default Context7 config: {mcp_use_config_path}")
+                    else:
+                        logger.error(f"Default Context7 config not found at {default_context7_path}. Context7 will be disabled. Ensure the file exists or provide a config via --mcp-use-config.")
+                        mcp_use_config_path = None
+
+                if mcp_use_config_path:
+                    config_repo.set("mcp_use_config", mcp_use_config_path)
+                    config_repo.set("mcp_use_enabled", True)
+                else:
+                    config_repo.set("mcp_use_enabled", False)
+
                 config_repo.set("cowboy_mode", args.cowboy_mode) # Also add here for non-server mode
 
-                # Validate custom tools function signatures
-                get_custom_tools()
+                # Initialize and register MCP-Use client for cleanup if enabled
+                mcp_use_client_instance = None
+                if config_repo.get("mcp_use_enabled", False):
+                    try:
+                        mcp_use_config = config_repo.get("mcp_use_config")
+                        # Import here to avoid circular dependency issues
+                        from ra_aid.utils.mcp_use_client import MCPUseClientSync 
+                        mcp_use_client_instance = MCPUseClientSync(mcp_use_config)
+                        # Register cleanup function
+                        atexit.register(mcp_use_client_instance.close)
+                        logger.info("MCP-Use client initialized and cleanup registered.")
+                    except Exception as e:
+                        logger.error(f"Failed to initialize MCP-Use client: {e}")
+                        # Ensure it's disabled if init fails
+                        config_repo.set("mcp_use_enabled", False) 
+
+                # Validate custom tools function signatures (this will now load MCP tools via the instance if available)
+                get_custom_tools(mcp_use_client=mcp_use_client_instance)
                 custom_tools_enabled = config_repo.get("custom_tools_enabled", False)
 
                 # Build status panel with memory statistics

--- a/ra_aid/prompts/research_prompts.py
+++ b/ra_aid/prompts/research_prompts.py
@@ -111,6 +111,9 @@ If you find this is an empty directory, you can stop research immediately and as
 {expert_section}
 {human_section}
 {web_research_section}
+    Context7 Tool Guidance:
+        If the task involves understanding or using specific libraries, frameworks, or APIs (e.g., React, Next.js, pandas, AWS SDK, Stripe API), **strongly prioritize** using the `resolve-library-id` and `get-library-docs` tools (if available) to fetch the most current documentation and examples *before* relying solely on your internal knowledge or web searches. Outdated information can lead to errors. Clearly state which library you are fetching documentation for when using these tools.
+
 {custom_tools_section}
 
     You have often been criticized for:

--- a/ra_aid/utils/mcp_use_client.py
+++ b/ra_aid/utils/mcp_use_client.py
@@ -1,0 +1,80 @@
+import asyncio
+import threading
+from typing import Any, List
+
+from langchain_core.tools import BaseTool
+from mcp_use import MCPClient
+from mcp_use.adapters.langchain_adapter import LangChainAdapter
+
+
+class MCPUseClientSync:
+    """Synchronous wrapper around ``mcp_use.MCPClient``.
+
+    ``mcp_use`` is fully async; RA.Aid’s tool-pipeline expects plain
+    synchronous ``langchain_core.tools.BaseTool`` instances.  This wrapper
+    starts a background event-loop, initializes the MCP client and converts
+    every server tool to a ``StructuredTool`` via the official
+    Note:
+        Using MCP servers often requires external dependencies managed by that
+        server. For example, using the Context7 server requires ``npx`` (Node.js)
+        to be available in the environment to run ``@upstash/context7-mcp``.
+
+    ``LangChainAdapter``.
+    """
+
+    def __init__(self, config: str | dict[str, Any]):
+        """Create the client.
+
+        Args:
+            config: Either a path to a JSON config file **or** a config dict
+                    compatible with ``MCPClient``.
+        """
+        self.loop = asyncio.new_event_loop()
+        self.thread = threading.Thread(target=self._run_loop, daemon=True)
+        self.thread.start()
+
+        self._client: MCPClient | None = None
+        self._tools: List[BaseTool] = []
+
+        fut = asyncio.run_coroutine_threadsafe(
+            self._setup_client(config), self.loop
+        )
+        fut.result()  # propagate any exceptions synchronously
+
+    # ---------------------------------------------------------------------
+    # public helpers
+    # ---------------------------------------------------------------------
+    def get_tools_sync(self) -> List[BaseTool]:
+        """Return the converted LangChain tools (synchronous)."""
+        return self._tools
+
+    def close(self) -> None:
+        """Close all MCP sessions and stop the event-loop."""
+        if self._client is not None:
+            fut = asyncio.run_coroutine_threadsafe(
+                self._client.close_all_sessions(), self.loop
+            )
+            fut.result()
+
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self.thread.join(timeout=5)
+
+    # ------------------------------------------------------------------
+    # internal
+    # ------------------------------------------------------------------
+    def _run_loop(self) -> None:
+        asyncio.set_event_loop(self.loop)
+        self.loop.run_forever()
+
+    async def _setup_client(self, config: str | dict[str, Any]):
+        if isinstance(config, str):
+            client = MCPClient.from_config_file(config)
+        else:
+            client = MCPClient.from_dict(config)
+
+        # create sessions for all declared servers so tools are available
+        await client.create_all_sessions(auto_initialize=True)
+
+        adapter = LangChainAdapter()
+        self._tools = await adapter.create_tools(client)
+        self._client = client


### PR DESCRIPTION
Adjusted the mcp tool to use the repo mcp-use from pietrozullo and the mcp server context7 from upstash to make a more extensible and compatible mcp capable agent, giving the agent the capacity to pull up to date documentation from thousands of packages using context 7