### PR TITLE
# Fix: Correct Token Limit Detection for OpenRouter Gemini 2.5 Pro

### DIFF
--- a/ra_aid/models_params.py
+++ b/ra_aid/models_params.py
@@ -315,7 +315,15 @@ models_params = {
             "latency_coefficient": DEFAULT_BASE_LATENCY,
             "max_tokens": 32000,
             "reasoning_assist_default": False,
-        }
+        },
+        "google/gemini-2.5-pro-preview-03-25": {
+            "token_limit": 1048576,
+            "max_tokens": 1048576, # Match token_limit as per gemini provider entry
+            "supports_temperature": True,
+            "default_temperature": 1.0, # Match gemini provider entry
+            "latency_coefficient": DEFAULT_BASE_LATENCY,
+            "default_backend": AgentBackendType.CIAYN, # Match gemini provider entry
+        },
     },
     "openai-compatible": {
         "qwen-qwq-32b": {


### PR DESCRIPTION
# Fix: Correct Token Limit Detection for OpenRouter Gemini 2.5 Pro

**Closes #222**

## Description

This pull request addresses an issue where the application failed to determine the correct context window size (token limit) for the `google/gemini-2.5-pro-preview-03-25` model when used via the `openrouter` provider.

The root cause was twofold:
1.  `litellm.model_info` could not resolve the provider-prefixed model name (`openrouter/google/gemini-2.5-pro-preview-03-25`) to get the token limit automatically.
2.  The fallback mechanism in `get_model_token_limit` (within `ra_aid/anthropic_token_limiter.py`) normalized the model name by removing hyphens (`google/gemini2.5propreview0325`) *before* looking it up in the `ra_aid/models_params.py` dictionary.

This resulted in the lookup failing even after the model was added to `models_params.py`, causing the system to default to a much smaller `DEFAULT_TOKEN_LIMIT` (100,000 tokens). This led to premature message trimming and degraded agent performance, particularly noticeable with large context tasks.

## Changes Made

1.  **`ra_aid/models_params.py`**:
    *   Added an entry for `google/gemini-2.5-pro-preview-03-25` under the `openrouter` provider section, specifying its correct `token_limit` (1,048,576).

2.  **`ra_aid/anthropic_token_limiter.py`**:
    *   Modified the fallback logic within the `get_model_token_limit` function.
    *   The function now first attempts to look up the **original** `model_name` (e.g., `google/gemini-2.5-pro-preview-03-25`) in the `models_params` dictionary for the given provider.
    *   Only if the original name is not found, it then attempts the lookup using the **normalized** name (e.g., `google/gemini2.5propreview0325`).

## How to Verify

1.  Configure the application to use `provider=openrouter` and `model=google/gemini-2.5-pro-preview-03-25`.
2.  Run the application and observe the debug logs during agent initialization (specifically from `ra_aid.anthropic_token_limiter`).
3.  Confirm that the logs now show the correct token limit being found via the direct lookup in `models_params`:
    ```
    DEBUG - Found token limit for openrouter/google/gemini-2.5-pro-preview-03-25 (direct lookup): 1048576
    ```
4.  Confirm that the calculated `max_input_tokens` for agent creation reflects this large limit, rather than the default 100,000.

This fix ensures that the correct, large context window is utilized for Gemini 2.5 Pro via OpenRouter, preventing excessive context loss and improving agent reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the "google/gemini-2.5-pro-preview-03-25" model with an increased token limit and enhanced configuration options.

- **Bug Fixes**
  - Improved fallback logic for retrieving model token limits, ensuring more reliable model support and clearer debug logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->