### PR TITLE
updates prompt input to fill available space

### DIFF
--- a/frontend/common/src/components/DefaultAgentScreen.tsx
+++ b/frontend/common/src/components/DefaultAgentScreen.tsx
@@ -440,18 +440,16 @@ export const DefaultAgentScreen: React.FC = () => {
           All done! Press <kbd className="px-1.5 py-0.5 border rounded bg-muted font-mono text-xs">Ctrl</kbd> + <kbd className="px-1.5 py-0.5 border rounded bg-muted font-mono text-xs">Space</kbd> to start a new session.
         </div>
       )}
-      {/* Input section for existing session (if needed) */}
-      {/* <InputSection onSubmit={handleSubmit} /> */}
     </div>
   ) : newSession ? (
     // New session composition view
     <div className="flex flex-col h-full w-full">
-      <div className="flex-1 overflow-auto w-full">
+      <div className="flex flex-col flex-1 overflow-auto w-full">
         {/* Session title */}
         <div className="px-6 pt-4 pb-2 border-b border-border/30">
           <h2 className="text-xl font-medium">Create New Session</h2>
         </div>
-        <div className="px-6 pt-3 pb-4">
+        <div className="px-6 pt-3 pb-4 flex flex-col flex-1 min-h-0">
           <p className="text-muted-foreground mb-6">
             Type your message in the input box below to start a new conversation with the agent.
           </p>
@@ -472,13 +470,13 @@ export const DefaultAgentScreen: React.FC = () => {
               </p>
             </div>
           </div>
+          {/* Input section for new session */}
+          <InputSection
+            isNewSession={true}
+            isDrawerOpen={isDrawerOpen}
+          />
         </div>
       </div>
-      {/* Input section for new session */}
-      <InputSection
-        isNewSession={true}
-        isDrawerOpen={isDrawerOpen}
-      />
     </div>
   ) : (
     // No session selected view

--- a/frontend/common/src/components/InputSection.tsx
+++ b/frontend/common/src/components/InputSection.tsx
@@ -152,11 +152,11 @@ export const InputSection: React.FC<InputSectionProps> = ({
 
   return (
     <div className={cn(
-      "fixed bottom-0 left-0 right-0 z-20 pointer-events-none md:left-[280px] lg:left-[320px] xl:left-[350px]",
+      "flex flex-col flex-1",
       className
     )}>
-      <div className="px-4 pb-4 pointer-events-none">
-        <div className="relative rounded-lg border border-input bg-background/95 backdrop-blur-sm shadow-md pointer-events-auto">
+      <div className="pt-4 flex flex-col flex-1 pointer-events-auto">
+        <div className="relative rounded-lg border border-input bg-background/95 backdrop-blur-sm shadow-md pointer-events-auto flex flex-col h-full">
           {isNewSession && (
             <div className="flex justify-between items-center pt-2 px-3">
               <div className="text-sm font-medium">Create New Session</div>
@@ -174,7 +174,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
               </Button>
             </div>
           )}
-          <form onSubmit={handleSubmit}>
+          <form onSubmit={handleSubmit} className="flex flex-col h-full">
             <textarea
               ref={textareaRef} // Attach the ref here
               value={message}
@@ -187,12 +187,12 @@ export const InputSection: React.FC<InputSectionProps> = ({
               }}
               onKeyDown={handleKeyDown} // <-- Add keydown handler
               placeholder={placeholder}
-              className="flex w-full resize-none rounded-lg border-0 bg-transparent px-3 py-2 pr-12 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50"
-              rows={isNewSession ? 4 : 3}
+              className="flex w-full resize-none rounded-lg border-0 bg-transparent px-3 py-2 pr-12 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 grow"
+              rows={isNewSession ? 1 : 3}
               disabled={isSubmitting}
             />
             {isNewSession ? (
-              <div className="flex items-center justify-end space-x-2 px-3 py-2 border-t border-border/30">{/* Changed justify-end */}
+              <div className="flex items-center justify-end space-x-2 px-3 py-2 border-t border-border/30">
                 <Button
                   type="button"
                   variant="outline"


### PR DESCRIPTION
This p/r updates the "Create New Session" input section to grow vertically into all remaining space.

## raaid output - plan completed

```mdx
# Plan Completed

The frontend components `DefaultAgentScreen.tsx` and `InputSection.tsx` have been successfully modified.

In `DefaultAgentScreen.tsx`, the `InputSection` component was moved within the 'new session' view to be a child of the main content area. The styling of its new parent container was updated to `flex flex-col h-full` to support a flexible, growing layout.

In `InputSection.tsx`, fixed positioning classes were removed from its outermost `div`. The internal structure was adjusted so that its main content area (textarea and buttons) can grow to fill available vertical space. This involved:
- Making the outermost div `flex flex-col h-full`.
- Modifying an intermediate wrapper `div` to also be `flex flex-col h-full pointer-events-auto`.
- Ensuring the main content `div` (containing the form) is `flex flex-col h-full`.
- The `form` element itself was also made `flex flex-col h-full`.
- The `textarea` had `flex-grow` (Tailwind `grow`) added to its classes and its `rows` attribute was changed to `rows={isNewSession ? 1 : 3}` to allow it to expand vertically in the new session view.

These changes achieve the desired outcome: the 'Create New Session' input area is no longer a fixed overlay but part of the main content flow, positioned at the bottom of the introductory content, and expands vertically to fill available space.
```

---

### before screenshot

![image](https://github.com/user-attachments/assets/4da02898-c313-423a-916d-42c02103976c)


### after screenshot

![image](https://github.com/user-attachments/assets/219bcc32-9309-49c2-be35-6c21e2e50468)
