### PR TITLE
Add EmpirioLabs AI open model example

### DIFF
--- a/docs/docs/quickstart/open-models.md
+++ b/docs/docs/quickstart/open-models.md
@@ -40,7 +40,6 @@ RA.Aid supports these model providers:
 export DEEPSEEK_API_KEY=your_key
 export FIREWORKS_API_KEY=your_key
 export MAKEHUB_API_KEY=your_key
-export EMPIRIOLABS_API_KEY=your_key
 export OPENROUTER_API_KEY=your_key
 export OPENAI_API_KEY=your_key
 export ANTHROPIC_API_KEY=your_key
@@ -136,12 +135,13 @@ EmpirioLabs AI exposes an OpenAI-compatible API for text, image, video, audio, s
 
 ```bash
 # Environment setup
+# RA.Aid reads the OpenAI-compatible variables at runtime.
 export EMPIRIOLABS_API_KEY=your_api_key_here
 export OPENAI_API_KEY=$EMPIRIOLABS_API_KEY
 export OPENAI_API_BASE=https://api.empiriolabs.ai/v1
 
 # Basic usage
-ra-aid -m "Your task" --provider openai-compatible --model qwen3-max
+ra-aid -m "Your task" --provider openai-compatible --model <model-id>
 ```
 
 **Available Models:**
@@ -342,8 +342,8 @@ Complete list of supported environment variables:
 | `DEEPSEEK_API_KEY`             | DeepSeek          | Main API access                                   |
 | `FIREWORKS_API_KEY`            | Fireworks         | Main API access                                   |
 | `MAKEHUB_API_KEY`              | MakeHub           | Main API access                                   |
-| `OPENAI_API_KEY`               | OpenAI-compatible | API access                                        |
-| `OPENAI_API_BASE`              | OpenAI-compatible | Custom endpoint                                   |
+| `OPENAI_API_KEY`               | OpenAI-compatible | Runtime API key, including mapped EmpirioLabs keys |
+| `OPENAI_API_BASE`              | OpenAI-compatible | Custom endpoint, including EmpirioLabs API base   |
 | `ANTHROPIC_API_KEY`            | Anthropic         | API access                                        |
 | `GEMINI_API_KEY`               | Gemini            | API access                                        |
 | `AWS_PROFILE`                  | Bedrock           | API access                                        |

--- a/docs/docs/quickstart/open-models.md
+++ b/docs/docs/quickstart/open-models.md
@@ -21,6 +21,7 @@ RA.Aid supports these model providers:
 | DeepSeek          | Chinese hedge fund who creates sophisticated LLMs       | Strong, open models like R1                                       |
 | Fireworks         | Serverless AI inference platform for open-source models | High-performance inference, pay-per-token, variety of open models |
 | MakeHub           | OpenAI-compatible AI router optimized for developers    | Customizable speed/price ratio, curated latest models, dev-optimized performance |
+| EmpirioLabs AI    | OpenAI-compatible API platform for multimodal models    | Unified API key, live model catalog, shared billing               |
 | OpenRouter        | Multi-model gateway service                             | Access to 100+ models, unified API interface, pay-per-token       |
 | OpenAI-compatible | Self-hosted model endpoints                             | Compatible with Llama, Mistral and other open models              |
 | Anthropic         | Claude model series                                     | 200k token context, strong tool use, JSON/XML parsing             |
@@ -39,6 +40,7 @@ RA.Aid supports these model providers:
 export DEEPSEEK_API_KEY=your_key
 export FIREWORKS_API_KEY=your_key
 export MAKEHUB_API_KEY=your_key
+export EMPIRIOLABS_API_KEY=your_key
 export OPENROUTER_API_KEY=your_key
 export OPENAI_API_KEY=your_key
 export ANTHROPIC_API_KEY=your_key
@@ -124,6 +126,26 @@ ra-aid -m "Your task" --provider makehub --model anthropic/claude-4-sonnet --tem
 - Configure `price_performance_ratio` for intelligent speed/cost optimization
 - Automatic routing to optimal endpoints - no manual base URL configuration needed
 - Expert mode support with `EXPERT_MAKEHUB_API_KEY` environment variable
+
+</TabItem>
+<TabItem value="empiriolabs" label="EmpirioLabs AI">
+
+### EmpirioLabs AI Integration
+
+EmpirioLabs AI exposes an OpenAI-compatible API for text, image, video, audio, search, and 3D models.
+
+```bash
+# Environment setup
+export EMPIRIOLABS_API_KEY=your_api_key_here
+export OPENAI_API_KEY=$EMPIRIOLABS_API_KEY
+export OPENAI_API_BASE=https://api.empiriolabs.ai/v1
+
+# Basic usage
+ra-aid -m "Your task" --provider openai-compatible --model qwen3-max
+```
+
+**Available Models:**
+- Use the current model IDs from the [EmpirioLabs model catalog](https://empiriolabs.ai/models).
 
 </TabItem>
 <TabItem value="openrouter" label="OpenRouter">


### PR DESCRIPTION
Summary:
- add EmpirioLabs AI to the open models provider table
- document setup through the OpenAI-compatible provider
- link the model catalog for current model IDs

Testing:
- Not run, docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the quickstart guide to add EmpirioLabs AI to the list of supported providers.
  * Added an “EmpirioLabs AI Integration” section with environment setup instructions, including required API key/base mapping and an example usage command.
  * Updated related environment variable descriptions and references to the EmpirioLabs model catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->